### PR TITLE
feat: add part removal menu

### DIFF
--- a/freeroamPartInventory/ui/modules/apps/freeroamPartInventory/app.html
+++ b/freeroamPartInventory/ui/modules/apps/freeroamPartInventory/app.html
@@ -1,11 +1,24 @@
 <div class="bngApp">
-  <h3>Part Inventory</h3>
-  <button ng-click="openConfig()">Vehicle Configuration</button>
-  <div class="inventory-list">
-    <div class="inventory-item" ng-repeat="part in inventory track by part.id">
-      <span>{{part.name}}</span>
-      <button ng-click="install(part.id)">Install</button>
+  <div ng-if="!showConfig">
+    <h3>Part Inventory</h3>
+    <button ng-click="openConfig()">Vehicle Configuration</button>
+    <div class="inventory-list">
+      <div class="inventory-item" ng-repeat="part in inventory track by part.id">
+        <span>{{part.name}}</span>
+        <button ng-click="install(part.id)">Install</button>
+      </div>
+      <div class="empty" ng-if="!inventory.length">No stored parts.</div>
     </div>
-    <div class="empty" ng-if="!inventory.length">No stored parts.</div>
+  </div>
+  <div ng-if="showConfig">
+    <h3>Vehicle Parts</h3>
+    <button ng-click="closeConfig()">Back</button>
+    <div class="inventory-list">
+      <div class="inventory-item" ng-repeat="part in vehicleParts track by part.slot">
+        <span>{{part.name}}</span>
+        <button ng-click="remove(part.slot)">Remove</button>
+      </div>
+      <div class="empty" ng-if="!vehicleParts.length">No removable parts.</div>
+    </div>
   </div>
 </div>

--- a/freeroamPartInventory/ui/modules/apps/freeroamPartInventory/app.js
+++ b/freeroamPartInventory/ui/modules/apps/freeroamPartInventory/app.js
@@ -7,14 +7,24 @@ angular.module('beamng.apps')
     scope: true,
     controller: ['$scope', function ($scope) {
       $scope.inventory = [];
+      $scope.vehicleParts = [];
+      $scope.showConfig = false;
 
       // Request initial data from Lua
       bngApi.engineLua('extensions.freeroamPartInventory.sendUIData()');
 
-      // Receive updates from Lua
+      // Receive updates for stored parts
       $scope.$on('freeroamPartInventoryData', function (event, data) {
         $scope.$evalAsync(function () {
           $scope.inventory = data.parts || [];
+        });
+      });
+
+      // Receive current vehicle parts when entering configuration view
+      $scope.$on('freeroamPartInventoryVehicleParts', function (event, data) {
+        $scope.$evalAsync(function () {
+          $scope.vehicleParts = data.parts || [];
+          $scope.showConfig = true;
         });
       });
 
@@ -23,9 +33,19 @@ angular.module('beamng.apps')
         bngApi.engineLua('extensions.freeroamPartInventory.installPart(' + id + ')');
       };
 
-      // Open vehicle configuration menu so the player can remove parts
+      // Remove a part from the current vehicle
+      $scope.remove = function (slot) {
+        bngApi.engineLua('extensions.freeroamPartInventory.removePart("' + slot + '")');
+      };
+
+      // Open vehicle configuration view
       $scope.openConfig = function () {
         bngApi.engineLua('extensions.freeroamPartInventory.openVehicleConfig()');
+      };
+
+      // Close configuration view
+      $scope.closeConfig = function () {
+        $scope.showConfig = false;
       };
     }]
   };


### PR DESCRIPTION
## Summary
- replace broken vehicle config state with custom part removal view
- allow removing installed parts and re-installing stored parts in one widget

## Testing
- `npm test` *(fails: Could not read package.json)*
- `luac -p freeroamPartInventory/lua/ge/extensions/freeroamPartInventory.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c486ce532c832980ce6021c4cc8eef