### PR TITLE
Add user paint palette selection

### DIFF
--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -380,6 +380,37 @@
       opacity: 0.85;
       font-weight: 600;
     }
+    .vehicle-parts-painting .paint-card .palette-field {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .vehicle-parts-painting .paint-card .palette-field label {
+      font-size: 10px;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      opacity: 0.75;
+    }
+    .vehicle-parts-painting .paint-card .palette-swatches {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+    .vehicle-parts-painting .paint-card .palette-swatch {
+      width: 26px;
+      height: 26px;
+      border-radius: 4px;
+      border: 1px solid rgba(255, 255, 255, 0.35);
+      padding: 0;
+      cursor: pointer;
+      background: transparent;
+      transition: border-color 0.15s ease;
+    }
+    .vehicle-parts-painting .paint-card .palette-swatch:hover,
+    .vehicle-parts-painting .paint-card .palette-swatch:focus {
+      border-color: rgba(255, 255, 255, 0.85);
+      outline: none;
+    }
     .vehicle-parts-painting .paint-card .field-row {
       display: flex;
       align-items: center;
@@ -545,6 +576,18 @@
                 <span>B</span>
                 <input type="range" min="0" max="255" step="1" ng-model="paint.color.b" ng-change="onColorChannelChanged(paint)">
                 <input type="number" min="0" max="255" step="1" ng-model="paint.color.b" ng-change="onColorChannelChanged(paint)">
+              </div>
+            </div>
+            <div class="palette-field" ng-if="state.userPaintPresetViews.length">
+              <label>Saved colors</label>
+              <div class="palette-swatches">
+                <button type="button"
+                        class="palette-swatch"
+                        ng-repeat="preset in state.userPaintPresetViews track by $index"
+                        ng-style="getColorPreviewStyle(preset)"
+                        ng-attr-title="'Preset ' + ($index + 1) + ' – ' + getColorHex(preset)"
+                        ng-attr-aria-label="'Apply saved color ' + ($index + 1)"
+                        ng-click="applyUserPaintPreset($index, $parent.$parent.$index)"></button>
               </div>
             </div>
           </div>

--- a/ui/modules/apps/vehiclePartsPainting/app.js
+++ b/ui/modules/apps/vehiclePartsPainting/app.js
@@ -40,6 +40,8 @@ angular.module('beamng.apps')
         partsTree: [],
         filteredTree: [],
         basePaints: [],
+        userPaintPresets: [],
+        userPaintPresetViews: [],
         selectedPartPath: null,
         selectedPart: null,
         highlightSuspended: false,
@@ -509,6 +511,17 @@ angular.module('beamng.apps')
         $scope.editedPaints[index] = createViewPaint(paint);
       };
 
+      $scope.applyUserPaintPreset = function (presetIndex, paintIndex) {
+        if (!Array.isArray(state.userPaintPresetViews) || !state.userPaintPresetViews.length) { return; }
+        if (typeof presetIndex !== 'number' || typeof paintIndex !== 'number') { return; }
+        if (presetIndex < 0 || presetIndex >= state.userPaintPresetViews.length) { return; }
+        if (paintIndex < 0 || paintIndex >= $scope.editedPaints.length) { return; }
+        const presetView = state.userPaintPresetViews[presetIndex];
+        if (!presetView) { return; }
+        $scope.editedPaints[paintIndex] = angular.copy(presetView);
+        syncHtmlColor($scope.editedPaints[paintIndex]);
+      };
+
       $scope.selectPart = function (part) {
         if (!part) { return; }
         setSelectedPart(part, { forceHighlight: true });
@@ -595,6 +608,8 @@ angular.module('beamng.apps')
 
           if (!state.vehicleId) {
             state.basePaints = [];
+            state.userPaintPresets = [];
+            state.userPaintPresetViews = [];
             state.parts = [];
             state.partsTree = [];
             state.filteredTree = [];
@@ -612,6 +627,11 @@ angular.module('beamng.apps')
           }
 
           state.basePaints = Array.isArray(data.basePaints) ? data.basePaints : [];
+          const userPaintPresets = Array.isArray(data.userPaintPresets) ? data.userPaintPresets : [];
+          state.userPaintPresets = copyPaints(userPaintPresets);
+          state.userPaintPresetViews = state.userPaintPresets.map(function (preset) {
+            return preset ? createViewPaint(preset) : null;
+          }).filter(function (preset) { return !!preset; });
           state.parts = Array.isArray(data.parts) ? data.parts : [];
           state.partsTree = buildPartsTree(state.parts);
 


### PR DESCRIPTION
## Summary
- expose saved user paint presets from settings to the vehicle parts painting state payload
- surface saved palette entries in the Angular app and allow applying them to edited paints
- style the palette selector and add swatch buttons to the paint editor UI

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68c9220fd3ec8329bc2e30b90dc982b9