### PR TITLE
Fix vehicle part visibility after leaving vehicles

### DIFF
--- a/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
+++ b/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
@@ -2246,11 +2246,15 @@ local function showAllParts(targetVehId)
   if not vehId or vehId == -1 then return end
 
   local vehObj = getObjectByID(vehId)
-  local vehData = vehManager.getVehicleData(vehId)
-  if not vehObj or not vehData then return end
+  if not vehObj then return end
+
+  local vehData = nil
+  if vehManager and type(vehManager.getVehicleData) == 'function' then
+    vehData = vehManager.getVehicleData(vehId)
+  end
 
   local highlight = validPartPathsByVeh[vehId]
-  if not highlight or tableIsEmpty(highlight) then
+  if (not highlight or tableIsEmpty(highlight)) and vehData then
     local basePaints = getVehicleBasePaints(vehData, vehObj)
     local availableParts = jbeamIO.getAvailableParts(vehData.ioCtx) or {}
     local tmpParts = {}
@@ -2290,11 +2294,16 @@ local function showAllParts(targetVehId)
 
   highlightedParts = {}
 
-  if highlight then
-    extensions.core_vehicle_partmgmt.highlightParts(highlight)
-    applyPartTransparency(vehId, nil)
-  else
-    vehObj:setMeshAlpha(1, "", false)
+  applyPartTransparency(vehId, nil)
+
+  local currentPlayerVehId = be:getPlayerVehicleID(0)
+  if vehId == currentPlayerVehId then
+    if extensions.core_vehicle_partmgmt and type(extensions.core_vehicle_partmgmt.highlightParts) == 'function' then
+      extensions.core_vehicle_partmgmt.highlightParts(highlight or {})
+    elseif vehObj then
+      vehObj:queueLuaCommand('bdebug.setPartsSelected({})')
+    end
+  elseif vehObj then
     vehObj:queueLuaCommand('bdebug.setPartsSelected({})')
   end
 end

--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -721,7 +721,9 @@
       <script type="text/ng-template" id="vehiclePartsPaintingTreeNode.html">
         <div class="part-node"
               ng-class="{selected: node.part.partPath === state.selectedPartPath}"
-              ng-click="selectPart(node.part)">
+              ng-click="selectPart(node.part)"
+              ng-mouseenter="onPartMouseEnter(node.part)"
+              ng-mouseleave="onPartMouseLeave(node.part)">
           <button type="button"
                   class="toggle"
                   ng-if="node.children && node.children.length"


### PR DESCRIPTION
## Summary
- track the last known player vehicle so we can detect player-related vehicle switch events even when the player flag is missing
- always restore full vehicle visibility when the player leaves or switches vehicles and refresh the tracked player vehicle id on related events

## Testing
- not run (beamng environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c9d3b397d48329a9398d472f19a681