### PR TITLE
Fix user vehicle config directories and custom paint persistence

### DIFF
--- a/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
+++ b/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
@@ -22,6 +22,8 @@ local colorPresetPreferencesPath = false
 local editorPreferencesCandidates = nil
 local lastKnownPlayerVehicleId = nil
 
+local collectCustomPartPaintsForSave -- forward declaration for fallback saves
+
 local function isLikelyPlayerVehicleId(vehId)
   if not vehId or vehId == -1 then
     return false
@@ -1929,7 +1931,7 @@ local function setConfigPaintsEntry(vehData, partPath, paints)
   end
 end
 
-local function collectCustomPartPaintsForSave(vehId, vehData)
+collectCustomPartPaintsForSave = function(vehId, vehData)
   local collected = {}
 
   if vehData and vehData.config and type(vehData.config.customPartPaints) == 'table' then


### PR DESCRIPTION
## Summary
- normalize directory creation to work with relative user paths so saved configs and previews end up in the correct vehicles folder
- ensure preview screenshots resolve to the proper absolute filename derived from the user path
- include sanitized custom part paint data when falling back to manual .pc saves

## Testing
- `luac -p lua/ge/extensions/freeroam/vehiclePartsPainting.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c9eef7ef588329828e7a3cbe25b0b4