### PR TITLE
Add configurable vehicle base paint

### DIFF
--- a/.tests/vehiclePartsPainting.test.js
+++ b/.tests/vehiclePartsPainting.test.js
@@ -290,6 +290,7 @@ function resetPaint(scope, partPath) {
 (function runTests() {
   const controller = instantiateController();
   const scope = controller.scope;
+  const bngApiCalls = controller.bngApiCalls;
   const hooks = controller.hooks;
 
   const basePaints = [
@@ -355,6 +356,25 @@ function resetPaint(scope, partPath) {
   resetPaint(scope, 'vehicle/root');
   node = findNode(state.filteredTree, 'vehicle/root');
   assert(node && !scope.hasCustomBadge(node.part), 'Part 1 custom paint badge should be cleared after reset');
+
+  assert(Array.isArray(scope.basePaintEditors) && scope.basePaintEditors.length === 3, 'Base paint editors should mirror vehicle paints');
+  scope.basePaintEditors[0].color.g = 128;
+  scope.basePaintEditors[0].color.b = 64;
+  scope.$digest();
+  assert(scope.hasBasePaintChanges(), 'Base paint change should be detected');
+  scope.applyBasePaints();
+  scope.$digest();
+  assert(!scope.hasBasePaintChanges(), 'Base paint change state should clear after apply');
+  const lastCommand = bngApiCalls[bngApiCalls.length - 1];
+  assert(lastCommand && lastCommand.startsWith('freeroam_vehiclePartsPainting.setVehicleBasePaintsJson('), 'Base paint command should be queued');
+  const updatedBasePaint = scope.state.basePaints[0];
+  assert(Math.abs(updatedBasePaint.baseColor[1] - (128 / 255)) < 0.001, 'Base paint green channel should update');
+  assert(Math.abs(updatedBasePaint.baseColor[2] - (64 / 255)) < 0.001, 'Base paint blue channel should update');
+  doorNode = findNode(state.filteredTree, 'vehicle/door');
+  const doorPaint = doorNode.part.currentPaints[0];
+  assert(Math.abs(doorPaint.baseColor[1] - (128 / 255)) < 0.001, 'Door part should inherit updated base paint');
+  assert(Math.abs(doorPaint.baseColor[2] - (64 / 255)) < 0.001, 'Door part should inherit updated base paint blue channel');
+  assert(!scope.hasCustomBadge(doorNode.part), 'Door should remain without a custom badge after base paint change');
 
   console.log('All vehicle parts painting tests passed.');
 })();

--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -816,6 +816,98 @@
           </div>
         </div>
       </div>-->
+      <div class="editor-panel base-paint-panel" ng-if="state.vehicleId">
+        <div class="part-summary">
+          <h3>Vehicle base paint</h3>
+          <div class="meta">Used for the vehicle paint and parts without custom colors.</div>
+        </div>
+        <div class="paint-editors">
+          <div class="paint-card" ng-repeat="paint in basePaintEditors track by $index">
+            <div class="card-header">
+              <h4>Paint {{$index + 1}}</h4>
+            </div>
+            <div class="field color-field">
+              <label>Color</label>
+              <div class="color-preview" ng-style="getColorPreviewStyle(paint)"></div>
+              <div class="html-color-input">
+                <label for="vehicleBasePaintHtmlColor{{$index}}">HTML color code</label>
+                <input id="vehicleBasePaintHtmlColor{{$index}}"
+                        type="text"
+                        ng-model="paint.htmlColor"
+                        ng-change="onHtmlColorInputChanged(paint)"
+                        ng-blur="onHtmlColorInputBlur(paint)"
+                        placeholder="#RRGGBB"
+                        maxlength="7"
+                        autocomplete="off"
+                        autocorrect="off"
+                        autocapitalize="none"
+                        spellcheck="false">
+              </div>
+              <div class="color-presets">
+                <div class="preset-list" ng-if="state.colorPresets.length">
+                  <button type="button"
+                          class="preset-swatch"
+                          ng-repeat="preset in state.colorPresets track by $index"
+                          ng-style="getColorPresetStyle(preset)"
+                          ng-attr-title="{{getColorPresetTitle(preset)}}"
+                          ng-click="applyColorPreset(paint, preset)"></button>
+                </div>
+              </div>
+              <div class="color-presets-empty" ng-if="!state.colorPresets.length">No saved colors yet.</div>
+              <div class="color-channels">
+                <div class="color-channel">
+                  <span>R</span>
+                  <input type="range" min="0" max="255" step="1" ng-model="paint.color.r" ng-change="onColorChannelChanged(paint)">
+                  <input type="number" min="0" max="255" step="1" ng-model="paint.color.r" ng-change="onColorChannelChanged(paint)">
+                </div>
+                <div class="color-channel">
+                  <span>G</span>
+                  <input type="range" min="0" max="255" step="1" ng-model="paint.color.g" ng-change="onColorChannelChanged(paint)">
+                  <input type="number" min="0" max="255" step="1" ng-model="paint.color.g" ng-change="onColorChannelChanged(paint)">
+                </div>
+                <div class="color-channel">
+                  <span>B</span>
+                  <input type="range" min="0" max="255" step="1" ng-model="paint.color.b" ng-change="onColorChannelChanged(paint)">
+                  <input type="number" min="0" max="255" step="1" ng-model="paint.color.b" ng-change="onColorChannelChanged(paint)">
+                </div>
+              </div>
+            </div>
+            <div class="field">
+              <label>Metallic</label>
+              <div class="field-row">
+                <input type="range" min="0" max="1" step="0.01" ng-model="paint.metallic">
+                <input type="number" min="0" max="1" step="0.01" ng-model="paint.metallic">
+              </div>
+            </div>
+            <div class="field">
+              <label>Roughness</label>
+              <div class="field-row">
+                <input type="range" min="0" max="1" step="0.01" ng-model="paint.roughness">
+                <input type="number" min="0" max="1" step="0.01" ng-model="paint.roughness">
+              </div>
+            </div>
+            <div class="field">
+              <label>Clearcoat</label>
+              <div class="field-row">
+                <input type="range" min="0" max="1" step="0.01" ng-model="paint.clearcoat">
+                <input type="number" min="0" max="1" step="0.01" ng-model="paint.clearcoat">
+              </div>
+            </div>
+            <div class="field">
+              <label>Clearcoat Roughness</label>
+              <div class="field-row">
+                <input type="range" min="0" max="1" step="0.01" ng-model="paint.clearcoatRoughness">
+                <input type="number" min="0" max="1" step="0.01" ng-model="paint.clearcoatRoughness">
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="editor-actions">
+          <button type="button" class="primary" ng-click="applyBasePaints()" ng-disabled="!basePaintEditors.length || !hasBasePaintChanges()">Apply base paint</button>
+          <button type="button" class="secondary" ng-click="resetBasePaintEditors()" ng-disabled="!basePaintEditors.length || !hasBasePaintChanges()">Revert changes</button>
+        </div>
+      </div>
+
       <div class="editor-panel" ng-if="state.selectedPart">
         <div class="part-summary">
           <h3>{{state.selectedPart.displayName || state.selectedPart.partName}}</h3>

--- a/ui/modules/apps/vehiclePartsPainting/app.js
+++ b/ui/modules/apps/vehiclePartsPainting/app.js
@@ -67,6 +67,7 @@ angular.module('beamng.apps')
 
       $scope.state = state;
       $scope.editedPaints = [];
+      $scope.basePaintEditors = [];
 
       const CUSTOM_BADGE_REFRESH_INTERVAL_MS = 750;
       let customBadgeRefreshPromise = null;
@@ -368,6 +369,49 @@ angular.module('beamng.apps')
         return result;
       }
 
+      function syncBasePaintEditorsFromState() {
+        if (!Array.isArray(state.basePaints) || !state.basePaints.length) {
+          $scope.basePaintEditors = [];
+          return;
+        }
+        $scope.basePaintEditors = convertPaintsToView(state.basePaints);
+      }
+
+      function getBasePaintEditorPaints() {
+        return viewToPaints($scope.basePaintEditors);
+      }
+
+      function updatePartsWithBasePaint(basePaints) {
+        if (!Array.isArray(state.parts) || !state.parts.length) { return; }
+        const baseClone = clonePaints(basePaints);
+        const hasBase = baseClone.length > 0;
+        let changed = false;
+        for (let i = 0; i < state.parts.length; i++) {
+          const part = state.parts[i];
+          if (!part || part.hasCustomPaint) { continue; }
+          const updatedPart = Object.assign({}, part, {
+            hasCustomPaint: false,
+            customPaints: null,
+            currentPaints: hasBase ? clonePaints(baseClone) : []
+          });
+          applyPartReplacement(updatedPart, i);
+          changed = true;
+        }
+        if (changed) {
+          computeFilteredParts();
+        }
+      }
+
+      function applyBasePaintsLocally(paints) {
+        const baseClone = clonePaints(paints);
+        state.basePaints = baseClone;
+        syncBasePaintEditorsFromState();
+        updatePartsWithBasePaint(baseClone);
+        refreshCustomBadgeVisibility();
+      }
+
+      syncBasePaintEditorsFromState();
+
       function resetPartLookup() {
         partLookup = Object.create(null);
         partIndexLookup = Object.create(null);
@@ -622,6 +666,26 @@ angular.module('beamng.apps')
           computeFilteredParts();
         }
       }
+
+      $scope.hasBasePaintChanges = function () {
+        if (!$scope.basePaintEditors || !$scope.basePaintEditors.length) { return false; }
+        const paints = getBasePaintEditorPaints();
+        return !paintCollectionsEqual(state.basePaints, paints);
+      };
+
+      $scope.applyBasePaints = function () {
+        if (!$scope.basePaintEditors || !$scope.basePaintEditors.length) { return; }
+        const paints = getBasePaintEditorPaints();
+        if (!paints.length) { return; }
+        applyBasePaintsLocally(paints);
+        const payload = { paints: paints };
+        const command = 'freeroam_vehiclePartsPainting.setVehicleBasePaintsJson(' + toLuaString(JSON.stringify(payload)) + ')';
+        bngApi.engineLua(command);
+      };
+
+      $scope.resetBasePaintEditors = function () {
+        syncBasePaintEditorsFromState();
+      };
 
       $scope.hasCustomBadge = function (part) {
         if (!part || !part.partPath) { return false; }
@@ -1315,6 +1379,7 @@ angular.module('beamng.apps')
             clearPendingReplacement();
             clearCustomPaintState();
             state.basePaints = [];
+            $scope.basePaintEditors = [];
             state.parts = [];
             resetPartLookup();
             state.partsTree = [];
@@ -1359,7 +1424,8 @@ angular.module('beamng.apps')
             clearCustomPaintState();
           }
 
-          state.basePaints = Array.isArray(data.basePaints) ? data.basePaints : [];
+          state.basePaints = Array.isArray(data.basePaints) ? clonePaints(data.basePaints) : [];
+          syncBasePaintEditorsFromState();
           state.parts = Array.isArray(data.parts) ? data.parts : [];
           rebuildPartLookup();
           rebuildCurrentPartsTree();


### PR DESCRIPTION
## Summary
- add back-end support for updating vehicle base paints and reapplying them to the player vehicle
- extend the vehicle parts painting UI with a vehicle base paint editor that syncs non-custom parts
- expand the test suite to cover the new base paint workflow and command dispatch

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca3c7a840c8329897592d9e962af61