### PR TITLE
Adjust base paint panel collapsed sizing

### DIFF
--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -481,6 +481,9 @@
       padding: 0;
       gap: 0;
     }
+    .vehicle-parts-painting .base-paint-panel.is-collapsed {
+      flex: 0 0 auto;
+    }
     .vehicle-parts-painting .base-paint-panel .base-paint-header {
       display: flex;
       align-items: flex-start;


### PR DESCRIPTION
## Summary
- prevent the base paint panel from reserving extra height when collapsed by disabling its flex growth

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca4e62a4448329a8895901aea7f0b7