### PR TITLE
Trigger screenshot generation after saving config

### DIFF
--- a/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
+++ b/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
@@ -1074,6 +1074,24 @@ local function saveCurrentUserConfig(configName)
 
         local okSave, resultOrErr = safePcall(saveEntryPoint, fileName)
         if okSave and resultOrErr ~= false then
+          local previewSelection = displayName
+          if not previewSelection or previewSelection == '' then
+            previewSelection = sanitizedBaseName
+          end
+          if type(previewSelection) == 'string' then
+            previewSelection = previewSelection:gsub('%.[Pp][Cc]$', '')
+          end
+          if previewSelection and previewSelection ~= '' then
+            local screenshotCreatorExtension = getLoadedExtension('util_screenshotCreator')
+            if screenshotCreatorExtension and type(screenshotCreatorExtension.startWork) == 'function' then
+              local okScreenshot, errScreenshot = safePcall(screenshotCreatorExtension.startWork, { selection = previewSelection })
+              if not okScreenshot then
+                log('W', logTag, string.format('Failed to trigger util_screenshotCreator for "%s": %s', tostring(previewSelection), tostring(errScreenshot)))
+              end
+            else
+              log('D', logTag, 'util_screenshotCreator extension unavailable or missing startWork; skipping screenshot generation')
+            end
+          end
           if displayName and displayName ~= '' then
             if displayName ~= sanitizedBaseName then
               log('I', logTag, string.format('Saved vehicle configuration "%s" to "%s" via core_vehicle_partmgmt.%s', tostring(displayName), tostring(fileName), tostring(saveEntryPointName)))

--- a/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
+++ b/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
@@ -17,6 +17,7 @@ local partDescriptorsByVeh = {}
 local activePartIdSetByVeh = {}
 local ensuredPartConditionsByVeh = {}
 local savedConfigCacheByVeh = {}
+local screenshotCreatorUnavailableLogged = false
 local userColorPresets = nil
 local colorPresetPreferencesPath = false
 local editorPreferencesCandidates = nil
@@ -1089,7 +1090,10 @@ local function saveCurrentUserConfig(configName)
                 log('W', logTag, string.format('Failed to trigger util_screenshotCreator for "%s": %s', tostring(previewSelection), tostring(errScreenshot)))
               end
             else
-              log('D', logTag, 'util_screenshotCreator extension unavailable or missing startWork; skipping screenshot generation')
+              if not screenshotCreatorUnavailableLogged then
+                log('D', logTag, 'util_screenshotCreator extension unavailable or missing startWork; skipping screenshot generation')
+                screenshotCreatorUnavailableLogged = true
+              end
             end
           end
           if displayName and displayName ~= '' then


### PR DESCRIPTION
## Summary
- trigger the util_screenshotCreator extension after successfully saving a vehicle configuration
- fall back gracefully when the screenshot creator is unavailable so saving continues to work as before

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca6139af8483298703552fbe4ee357