### PR TITLE
Add UI and backend support for deleting user color presets

### DIFF
--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -77,12 +77,45 @@
     .vehicle-parts-painting .config-confirm-dialog .dialog-actions .confirm:hover {
       background: rgba(0, 170, 255, 1);
     }
+    .vehicle-parts-painting .config-confirm-dialog .dialog-actions .danger {
+      background: rgba(220, 53, 69, 0.9);
+      color: #fff;
+    }
+    .vehicle-parts-painting .config-confirm-dialog .dialog-actions .danger:hover {
+      background: rgba(220, 53, 69, 1);
+    }
     .vehicle-parts-painting .config-confirm-dialog .dialog-actions .cancel {
       background: rgba(255, 255, 255, 0.15);
       color: #fff;
     }
     .vehicle-parts-painting .config-confirm-dialog .dialog-actions .cancel:hover {
       background: rgba(255, 255, 255, 0.25);
+    }
+    .vehicle-parts-painting .color-delete-dialog .delete-color-preview {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 16px;
+    }
+    .vehicle-parts-painting .color-delete-dialog .delete-color-swatch {
+      width: 44px;
+      height: 44px;
+      border-radius: 4px;
+      border: 1px solid rgba(255, 255, 255, 0.35);
+      background: transparent;
+    }
+    .vehicle-parts-painting .color-delete-dialog .delete-color-label {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    .vehicle-parts-painting .color-delete-dialog .delete-color-name {
+      font-weight: 600;
+      font-size: 14px;
+    }
+    .vehicle-parts-painting .color-delete-dialog .delete-color-meta {
+      font-size: 12px;
+      color: rgba(255, 255, 255, 0.7);
     }
     .vehicle-parts-painting .app-content {
       flex: 1;
@@ -690,15 +723,46 @@
       gap: 6px;
     }
     .vehicle-parts-painting .paint-card .color-field .color-presets .preset-swatch {
-      width: 26px;
-      height: 26px;
+      position: relative;
+      width: 30px;
+      height: 30px;
+      flex: 0 0 auto;
+    }
+    .vehicle-parts-painting .paint-card .color-field .color-presets .preset-swatch-button {
+      width: 100%;
+      height: 100%;
       border-radius: 4px;
       border: 1px solid rgba(255, 255, 255, 0.35);
       padding: 0;
       background: transparent;
     }
-    .vehicle-parts-painting .paint-card .color-field .color-presets .preset-swatch:hover {
+    .vehicle-parts-painting .paint-card .color-field .color-presets .preset-swatch-button:hover,
+    .vehicle-parts-painting .paint-card .color-field .color-presets .preset-swatch-button:focus {
       border-color: rgba(255, 255, 255, 0.75);
+      outline: none;
+    }
+    .vehicle-parts-painting .paint-card .color-field .color-presets .preset-delete {
+      position: absolute;
+      top: -6px;
+      right: -6px;
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      border: 1px solid rgba(255, 255, 255, 0.35);
+      background: rgba(0, 0, 0, 0.65);
+      color: #fff;
+      font-size: 12px;
+      line-height: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0;
+    }
+    .vehicle-parts-painting .paint-card .color-field .color-presets .preset-delete:hover,
+    .vehicle-parts-painting .paint-card .color-field .color-presets .preset-delete:focus {
+      background: rgba(220, 53, 69, 0.9);
+      border-color: rgba(255, 255, 255, 0.6);
+      outline: none;
     }
     .vehicle-parts-painting .paint-card .color-field .color-presets-empty {
       font-size: 11px;
@@ -786,6 +850,24 @@
       <div class="dialog-actions">
         <button type="button" class="cancel" ng-click="cancelReplaceSavedConfig()">Cancel</button>
         <button type="button" class="confirm" ng-click="confirmReplaceSavedConfig()">Replace</button>
+      </div>
+    </div>
+  </div>
+  <div class="config-confirm-overlay" ng-if="state.showDeleteColorPresetDialog && state.pendingDeleteColorPreset">
+    <div class="config-confirm-dialog color-delete-dialog">
+      <h4>Delete color preset</h4>
+      <p>Do you want to delete this color from your user palette?</p>
+      <div class="delete-color-preview">
+        <div class="delete-color-swatch" ng-style="getColorPresetStyle(state.pendingDeleteColorPreset)"></div>
+        <div class="delete-color-label">
+          <div class="delete-color-name">{{state.pendingDeleteColorPreset.title || state.pendingDeleteColorPreset.name}}</div>
+          <div class="delete-color-meta"
+               ng-if="state.pendingDeleteColorPreset.title && state.pendingDeleteColorPreset.name && state.pendingDeleteColorPreset.title !== state.pendingDeleteColorPreset.name">{{state.pendingDeleteColorPreset.name}}</div>
+        </div>
+      </div>
+      <div class="dialog-actions">
+        <button type="button" class="cancel" ng-click="cancelDeleteColorPreset()">Cancel</button>
+        <button type="button" class="confirm danger" ng-click="confirmDeleteColorPreset()">Delete</button>
       </div>
     </div>
   </div>
@@ -961,12 +1043,21 @@
                   <div class="palette-body" ng-if="!isUserPaletteCollapsed(paint)">
                     <div class="color-presets" ng-if="state.colorPresets.length">
                       <div class="preset-list">
-                        <button type="button"
-                                class="preset-swatch"
-                                ng-repeat="preset in state.colorPresets track by $index"
-                                ng-style="getColorPresetStyle(preset)"
-                                ng-attr-title="{{getColorPresetTitle(preset)}}"
-                                ng-click="applyColorPreset(paint, preset)"></button>
+                        <div class="preset-swatch"
+                             ng-repeat="preset in state.colorPresets track by $index">
+                          <button type="button"
+                                  class="preset-swatch-button"
+                                  ng-style="getColorPresetStyle(preset)"
+                                  ng-attr-title="{{getColorPresetTitle(preset)}}"
+                                  ng-click="applyColorPreset(paint, preset)"></button>
+                          <button type="button"
+                                  class="preset-delete"
+                                  title="Delete color"
+                                  ng-attr-aria-label="Delete color preset {{preset.name || preset.title}}"
+                                  ng-click="promptDeleteColorPreset(preset, $event)">
+                            &times;
+                          </button>
+                        </div>
                       </div>
                     </div>
                     <div class="color-presets-empty" ng-if="!state.colorPresets.length">No saved colors yet.</div>
@@ -1075,12 +1166,21 @@
                 <div class="palette-body" ng-if="!isUserPaletteCollapsed(paint)">
                   <div class="color-presets" ng-if="state.colorPresets.length">
                     <div class="preset-list">
-                      <button type="button"
-                              class="preset-swatch"
-                              ng-repeat="preset in state.colorPresets track by $index"
-                              ng-style="getColorPresetStyle(preset)"
-                              ng-attr-title="{{getColorPresetTitle(preset)}}"
-                              ng-click="applyColorPreset(paint, preset)"></button>
+                      <div class="preset-swatch"
+                           ng-repeat="preset in state.colorPresets track by $index">
+                        <button type="button"
+                                class="preset-swatch-button"
+                                ng-style="getColorPresetStyle(preset)"
+                                ng-attr-title="{{getColorPresetTitle(preset)}}"
+                                ng-click="applyColorPreset(paint, preset)"></button>
+                        <button type="button"
+                                class="preset-delete"
+                                title="Delete color"
+                                ng-attr-aria-label="Delete color preset {{preset.name || preset.title}}"
+                                ng-click="promptDeleteColorPreset(preset, $event)">
+                          &times;
+                        </button>
+                      </div>
                     </div>
                   </div>
                   <div class="color-presets-empty" ng-if="!state.colorPresets.length">No saved colors yet.</div>


### PR DESCRIPTION
## Summary
- add a delete confirmation dialog for user palette colors with swatch previews and dedicated remove controls on each palette entry
- extend the Angular controller to manage palette deletion state, update the view immediately, and call a new backend removal command
- implement Lua backend support to remove color presets from disk and broadcast the updated palette to the UI

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca691aaa308329a5be87c973dff863