### PR TITLE
Integrate Vehicle Parts Painting into Freeroam top bar

### DIFF
--- a/docs/topbar_integration_plan.md
+++ b/docs/topbar_integration_plan.md
@@ -1,0 +1,48 @@
+# Vehicle Parts Painting Top Bar Integration Plan
+
+## Observations from the base UI
+
+* The Vue top bar store keeps the registered items in a dictionary that is sorted by `order` and matched against either `targetState` or a `substate` prefix when determining which button is active. Hidden state filtering relies on flag arrays such as `inGameOnly`, `noMission`, or `noScenario`.【F:.beamng/orig-0.36/ui/ui/ui-vue/src/services/topBar.js†L29-L145】
+* The store only starts listening once the `ui_topBar` Lua extension is loaded, then pulls the initial payload through `Lua.ui_topBar.requestData()` and expects future updates via the extension events (e.g. `ui_topBar_entriesChanged`).【F:.beamng/orig-0.36/ui/ui/ui-vue/src/services/topBar.js†L244-L258】
+* Freeroam currently exposes vehicle-related options in Angular under the `menu.vehicleconfig.*` states, each mapped to `/vehicle-config` URLs and toggling the UI apps layer as needed.【F:.beamng/orig-0.36/ui/ui/entrypoints/main/main.js†L440-L461】
+* The legacy dash menu still defines section breakpoints for Freeroam in front of `menu.vehicleconfig.parts`, `menu.environment`, `menu.photomode`, and `menu.options.graphics`, which gives us a natural insertion point for another vehicle-focused tool.【F:.beamng/orig-0.36/ui/ui/entrypoints/main/main.js†L2026-L2030】
+* The Vue router marks the `menu.vehicleconfig` branch with `topBar.visible = true`, signalling that top bar buttons should remain available while those views are shown.【F:.beamng/orig-0.36/ui/ui/ui-vue/src/modules/vehicleConfig/routes.js†L17-L33】
+
+## Current app structure
+
+* The `vehiclePartsPainting` Angular directive already bundles all UI logic and can be embedded inside another template by rendering the `<vehicle-parts-painting>` element.【F:ui/modules/apps/vehiclePartsPainting/app.js†L1-L40】
+
+## Proposed changes
+
+1. **Lua: extend the top bar inventory**
+   * Ship a small helper extension (e.g. `lua/ge/extensions/ui_topBar_vehiclePartsPainting.lua`) that waits for `ui_topBar` to load, clones the existing item table, and registers a new entry such as:
+     ```lua
+     local item = {
+       id = "vehiclePartsPainting",
+       label = "vehiclePartsPainting.topbarLabel",
+       icon = "engine",
+       targetState = "menu.vehiclePartsPainting",
+       substate = "menu.vehiclePartsPainting",
+       order = 250,
+       flags = {"inGameOnly", "noMission", "noScenario", "noGarage"}
+     }
+     ```
+   * When our extension loads, call into `extensions.ui_topBar` to append the item and emit `entriesChanged` so the store refreshes. Also register listeners for removal when unloading to keep the list clean.
+
+2. **Angular state & template wrapper**
+   * Provide a module (e.g. `ui/modules/menu/menu-vehiclePartsPainting.js`) that runs during Angular bootstrap and registers a new `$stateProvider.state('menu.vehiclePartsPainting', …)` mirroring the `menu.vehicleconfig` setup:
+     * URL `/vehicle-parts-painting`.
+     * `template` containing `<vehicle-parts-painting ui-sref-opts="{ inherit: true }"></vehicle-parts-painting>` with a lightweight controller that keeps the scope alive.
+     * `uiAppsShown: true` so the existing HUD layout remains visible.
+     * `backState: "BACK_TO_MENU"` for consistent navigation.
+
+3. **Vue route bridging**
+   * Add a small router module under `ui/modules/...` that exports a `/vehicle-parts-painting` route (`name: "menu.vehiclePartsPainting"`) with `meta.topBar.visible = true`. This ensures the Vue layout keeps the top bar active when our state is selected.
+
+4. **Translations & assets**
+   * Register a translation key (e.g. `vehiclePartsPainting.topbarLabel`) so the new button shows a localized caption, and reuse the existing app icon or add a simple SVG if needed.
+
+5. **Lifecycle coordination**
+   * When the Angular state is entered, request `Lua.vehiclePartsPainting.open()` to populate the directive just like the app version does today. When leaving, notify Lua so per-vehicle state can be released.
+
+Implementing these steps will add a dedicated “Vehicle Parts Painting” button next to the existing Freeroam vehicle tools, open our UI inside a menu frame similar to Vehicle Configuration, and keep the experience consistent with the current top bar conventions.

--- a/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
+++ b/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
@@ -19,6 +19,7 @@ local ensuredPartConditionsByVeh = {}
 local savedConfigCacheByVeh = {}
 local userColorPresets = nil
 local lastKnownPlayerVehicleId = nil
+local menuOpenCount = 0
 
 local sanitizeColorPresetEntry
 
@@ -2311,6 +2312,34 @@ local function onVehicleSwitched(oldId, newId, player)
   end
 end
 
+local function onMenuOpened()
+  menuOpenCount = menuOpenCount + 1
+  if menuOpenCount ~= 1 then
+    return
+  end
+
+  requestState()
+  requestSavedConfigs()
+
+  local vehId = be:getPlayerVehicleID(0)
+  if vehId and vehId ~= -1 then
+    applyStoredPaints(vehId)
+  end
+end
+
+local function onMenuClosed()
+  if menuOpenCount > 0 then
+    menuOpenCount = menuOpenCount - 1
+  end
+
+  if menuOpenCount > 0 then
+    return
+  end
+
+  clearHighlight()
+  showAllParts()
+end
+
 local function onExtensionLoaded()
   storedPartPaintsByVeh = {}
   validPartPathsByVeh = {}
@@ -2367,6 +2396,8 @@ M.onVehicleSpawned = onVehicleSpawned
 M.onVehicleResetted = onVehicleResetted
 M.onVehicleDestroyed = onVehicleDestroyed
 M.onVehicleSwitched = onVehicleSwitched
+M.onMenuOpened = onMenuOpened
+M.onMenuClosed = onMenuClosed
 M.onExtensionLoaded = onExtensionLoaded
 M.onExtensionUnloaded = onExtensionUnloaded
 

--- a/lua/ge/extensions/ui_topBar_vehiclePartsPainting.lua
+++ b/lua/ge/extensions/ui_topBar_vehiclePartsPainting.lua
@@ -157,8 +157,8 @@ local function refreshEntriesFromTopBar()
     return true
   end
 
-  safeCall(topBar, 'requestEntries')
-  return false
+  ok = safeCall(topBar, 'requestEntries')
+  return ok
 end
 
 local function registerItem()
@@ -181,11 +181,10 @@ local function registerItem()
     return true
   end
 
-  -- As a last resort, emit our own payload so the UI learns about the button
-  triggerEntriesChanged({})
-  triggerVisibleItems()
   registered = true
-  return true
+  triggerVisibleItems()
+  log('W', logTag, 'Failed to request ui_topBar entries while registering vehiclePartsPainting button')
+  return false
 end
 
 local function unregisterItem()
@@ -214,9 +213,10 @@ local function unregisterItem()
     end
     safeCall(topBar, 'unregisterItem', itemId)
     safeCall(topBar, 'removeItem', itemId)
+    safeCall(topBar, 'requestEntries')
   end
 
-  triggerEntriesChanged({}, true)
+  triggerVisibleItems()
 end
 
 local function onExtensionLoaded()

--- a/lua/ge/extensions/ui_topBar_vehiclePartsPainting.lua
+++ b/lua/ge/extensions/ui_topBar_vehiclePartsPainting.lua
@@ -1,0 +1,233 @@
+-- This Source Code Form is subject to the terms of the bCDDL, v. 1.1.
+-- If a copy of the bCDDL was not distributed with this
+-- file, You can obtain one at http://beamng.com/bCDDL-1.1.txt
+
+local M = {}
+
+local logTag = 'vehiclePartsPaintingTopBar'
+local itemId = 'vehiclePartsPainting'
+
+local itemDefinition = {
+  id = itemId,
+  label = 'vehiclePartsPainting.topbarLabel',
+  icon = 'engine',
+  targetState = 'menu.vehiclePartsPainting',
+  substate = 'menu.vehiclePartsPainting',
+  order = 250,
+  flags = {
+    'inGameOnly',
+    'noMission',
+    'noScenario',
+    'noGarage'
+  }
+}
+
+local registered = false
+
+local function deepCopy(value)
+  if type(value) ~= 'table' then
+    return value
+  end
+  local copy = {}
+  for k, v in pairs(value) do
+    copy[deepCopy(k)] = deepCopy(v)
+  end
+  return copy
+end
+
+local function getExtensionsTable()
+  local globalEnv = _G
+  if type(globalEnv) ~= 'table' then
+    return nil
+  end
+  local manager = rawget(globalEnv, 'extensions')
+  if type(manager) ~= 'table' then
+    return nil
+  end
+  return manager
+end
+
+local function getTopBarExtension()
+  local manager = getExtensionsTable()
+  if not manager then
+    return nil
+  end
+  local extension = rawget(manager, 'ui_topBar')
+  if type(extension) ~= 'table' then
+    return nil
+  end
+  return extension
+end
+
+local function safeCall(topBar, method, ...)
+  if not topBar then
+    return false
+  end
+  local fn = topBar[method]
+  if type(fn) ~= 'function' then
+    return false
+  end
+  local ok, result = pcall(fn, topBar, ...)
+  if not ok then
+    log('W', logTag, string.format('ui_topBar.%s failed: %s', tostring(method), tostring(result)))
+    return false
+  end
+  return true, result
+end
+
+local function ensureItem(entries)
+  if type(entries) ~= 'table' then
+    entries = {}
+  end
+  if entries[itemId] then
+    return entries
+  end
+  entries[itemId] = deepCopy(itemDefinition)
+  return entries
+end
+
+local function triggerEntriesChanged(entries, skipEnsure)
+  if type(guihooks) ~= 'table' or type(guihooks.trigger) ~= 'function' then
+    return
+  end
+  local payload = deepCopy(entries or {})
+  if not skipEnsure then
+    payload = ensureItem(payload)
+  end
+  guihooks.trigger('ui_topBar_entriesChanged', payload)
+end
+
+local function triggerVisibleItems()
+  if type(guihooks) ~= 'table' or type(guihooks.trigger) ~= 'function' then
+    return
+  end
+  guihooks.trigger('ui_topBar_visibleItemsChanged', {})
+end
+
+local function tryRegisterThroughApi()
+  local topBar = getTopBarExtension()
+  if not topBar then
+    return false
+  end
+
+  local ok, entries = safeCall(topBar, 'getEntries')
+  if ok and type(entries) == 'table' then
+    entries = ensureItem(entries)
+    if safeCall(topBar, 'setEntries', entries) then
+      return true
+    end
+  end
+
+  ok, entries = safeCall(topBar, 'getItems')
+  if ok and type(entries) == 'table' then
+    entries = ensureItem(entries)
+    if safeCall(topBar, 'setItems', entries) then
+      return true
+    end
+  end
+
+  if safeCall(topBar, 'registerItem', deepCopy(itemDefinition)) then
+    return true
+  end
+  if safeCall(topBar, 'addItem', deepCopy(itemDefinition)) then
+    return true
+  end
+  if safeCall(topBar, 'appendItem', deepCopy(itemDefinition)) then
+    return true
+  end
+
+  return false
+end
+
+local function refreshEntriesFromTopBar()
+  local topBar = getTopBarExtension()
+  if not topBar then
+    return false
+  end
+
+  local ok, entries = safeCall(topBar, 'getEntries')
+  if ok and type(entries) == 'table' then
+    triggerEntriesChanged(entries)
+    return true
+  end
+
+  ok, entries = safeCall(topBar, 'getItems')
+  if ok and type(entries) == 'table' then
+    triggerEntriesChanged(entries)
+    return true
+  end
+
+  safeCall(topBar, 'requestEntries')
+  return false
+end
+
+local function registerItem()
+  if registered then
+    return true
+  end
+
+  local success = tryRegisterThroughApi()
+  if success then
+    registered = true
+    refreshEntriesFromTopBar()
+    triggerVisibleItems()
+    return true
+  end
+
+  -- Fallback: request entries and append our item through the UI bridge
+  if refreshEntriesFromTopBar() then
+    registered = true
+    triggerVisibleItems()
+    return true
+  end
+
+  -- As a last resort, emit our own payload so the UI learns about the button
+  triggerEntriesChanged({})
+  triggerVisibleItems()
+  registered = true
+  return true
+end
+
+local function unregisterItem()
+  if not registered then
+    return
+  end
+  registered = false
+
+  local topBar = getTopBarExtension()
+  if topBar then
+    local ok, entries = safeCall(topBar, 'getEntries')
+    if ok and type(entries) == 'table' then
+      entries[itemId] = nil
+      if safeCall(topBar, 'setEntries', entries) then
+        triggerEntriesChanged(entries)
+        return
+      end
+    end
+    ok, entries = safeCall(topBar, 'getItems')
+    if ok and type(entries) == 'table' then
+      entries[itemId] = nil
+      if safeCall(topBar, 'setItems', entries) then
+        triggerEntriesChanged(entries)
+        return
+      end
+    end
+    safeCall(topBar, 'unregisterItem', itemId)
+    safeCall(topBar, 'removeItem', itemId)
+  end
+
+  triggerEntriesChanged({}, true)
+end
+
+local function onExtensionLoaded()
+  registerItem()
+end
+
+local function onExtensionUnloaded()
+  unregisterItem()
+end
+
+M.onExtensionLoaded = onExtensionLoaded
+M.onExtensionUnloaded = onExtensionUnloaded
+
+return M

--- a/ui/modModules/vehiclePartsPaintingTopBar/vehiclePartsPaintingTopBar.js
+++ b/ui/modModules/vehiclePartsPaintingTopBar/vehiclePartsPaintingTopBar.js
@@ -1,0 +1,7 @@
+import '/ui/modules/menu/menu-vehiclePartsPainting.js'
+import '/ui/modules/vehiclePartsPainting/vueIntegration.js'
+
+(function () {
+  'use strict'
+  angular.module('vehiclePartsPaintingTopBar', [])
+})()

--- a/ui/modules/menu/menu-vehiclePartsPainting.js
+++ b/ui/modules/menu/menu-vehiclePartsPainting.js
@@ -1,0 +1,109 @@
+(function () {
+  'use strict';
+
+  const TOPBAR_ITEM_ID = 'vehiclePartsPainting';
+  const TOPBAR_TEMPLATE = {
+    id: TOPBAR_ITEM_ID,
+    label: 'vehiclePartsPainting.topbarLabel',
+    icon: 'engine',
+    targetState: 'menu.vehiclePartsPainting',
+    substate: 'menu.vehiclePartsPainting',
+    order: 250,
+    flags: ['inGameOnly', 'noMission', 'noScenario', 'noGarage']
+  };
+
+  function getBridgeEvents() {
+    if (window.bridge && window.bridge.events) {
+      return window.bridge.events;
+    }
+    if (window.bngVue && window.bngVue.$game && window.bngVue.$game.events) {
+      return window.bngVue.$game.events;
+    }
+    return null;
+  }
+
+  function ensureTopBarItem(container) {
+    if (!container || typeof container !== 'object') { return; }
+    if (container[TOPBAR_ITEM_ID]) { return; }
+    container[TOPBAR_ITEM_ID] = angular.copy(TOPBAR_TEMPLATE);
+  }
+
+  function mutateDataPayload(payload) {
+    if (!payload || typeof payload !== 'object') { return; }
+    if (payload.items && typeof payload.items === 'object') {
+      ensureTopBarItem(payload.items);
+    } else {
+      ensureTopBarItem(payload);
+    }
+  }
+
+  function activateTopBar() {
+    const topBar = window.bngVue && window.bngVue.topBar;
+    if (!topBar) { return; }
+
+    if (typeof topBar.show === 'function') {
+      topBar.show();
+    }
+    if (typeof topBar.selectEntry === 'function') {
+      topBar.selectEntry(TOPBAR_ITEM_ID);
+    }
+    if (typeof topBar.onUIStateChanged === 'function') {
+      topBar.onUIStateChanged({ name: 'menu.vehiclePartsPainting', fullPath: '/menu.vehiclePartsPainting' });
+    }
+  }
+
+  angular.module('beamng.stuff')
+    .config(['$stateProvider', function ($stateProvider) {
+      $stateProvider.state('menu.vehiclePartsPainting', {
+        url: '/vehicle-parts-painting',
+        template: '<vehicle-parts-painting ui-sref-opts="{ inherit: true }"></vehicle-parts-painting>',
+        controller: 'VehiclePartsPaintingMenuCtrl',
+        uiAppsShown: true,
+        backState: 'BACK_TO_MENU'
+      });
+    }])
+    .run(['$rootScope', 'bngApi', function ($rootScope, bngApi) {
+      if (bngApi && typeof bngApi.engineLua === 'function') {
+        bngApi.engineLua('extensions.load("ui_topBar_vehiclePartsPainting")');
+      }
+
+      const events = getBridgeEvents();
+      if (!events || typeof events.on !== 'function') { return; }
+
+      const onDataRequested = function (payload) {
+        mutateDataPayload(payload);
+      };
+      const onEntriesChanged = function (payload) {
+        mutateDataPayload(payload);
+      };
+
+      events.on('ui_topBar_dataRequested', onDataRequested);
+      events.on('ui_topBar_entriesChanged', onEntriesChanged);
+
+      $rootScope.$on('$destroy', function () {
+        if (typeof events.off === 'function') {
+          events.off('ui_topBar_dataRequested', onDataRequested);
+          events.off('ui_topBar_entriesChanged', onEntriesChanged);
+        }
+      });
+    }])
+    .controller('VehiclePartsPaintingMenuCtrl', ['$scope', 'bngApi', function ($scope, bngApi) {
+      const events = getBridgeEvents();
+
+      activateTopBar();
+      if (events && typeof events.emit === 'function') {
+        events.emit('ui_topBar_uiStateChanged', { name: 'menu.vehiclePartsPainting', fullPath: '/menu.vehiclePartsPainting' });
+      }
+
+      if (bngApi && typeof bngApi.engineLua === 'function') {
+        bngApi.engineLua('extensions.load("freeroam_vehiclePartsPainting")');
+        bngApi.engineLua('freeroam_vehiclePartsPainting.onMenuOpened()');
+      }
+
+      $scope.$on('$destroy', function () {
+        if (bngApi && typeof bngApi.engineLua === 'function') {
+          bngApi.engineLua('freeroam_vehiclePartsPainting.onMenuClosed()');
+        }
+      });
+    }]);
+})();

--- a/ui/modules/menu/menu-vehiclePartsPainting.js
+++ b/ui/modules/menu/menu-vehiclePartsPainting.js
@@ -64,7 +64,10 @@
     }])
     .run(['$rootScope', 'bngApi', function ($rootScope, bngApi) {
       if (bngApi && typeof bngApi.engineLua === 'function') {
-        bngApi.engineLua('extensions.load("ui_topBar_vehiclePartsPainting")');
+        bngApi.engineLua([
+          'extensions.load("ui_topBar_vehiclePartsPainting")',
+          'ui_topBar_vehiclePartsPainting.ensureRegistered()'
+        ].join('; '));
       }
 
       const events = getBridgeEvents();
@@ -96,8 +99,14 @@
       }
 
       if (bngApi && typeof bngApi.engineLua === 'function') {
-        bngApi.engineLua('extensions.load("freeroam_vehiclePartsPainting")');
-        bngApi.engineLua('freeroam_vehiclePartsPainting.onMenuOpened()');
+        bngApi.engineLua([
+          'extensions.load("ui_topBar_vehiclePartsPainting")',
+          'ui_topBar_vehiclePartsPainting.ensureRegistered()'
+        ].join('; '));
+        bngApi.engineLua([
+          'extensions.load("freeroam_vehiclePartsPainting")',
+          'freeroam_vehiclePartsPainting.onMenuOpened()'
+        ].join('; '));
       }
 
       $scope.$on('$destroy', function () {

--- a/ui/modules/vehiclePartsPainting/vueIntegration.js
+++ b/ui/modules/vehiclePartsPainting/vueIntegration.js
@@ -1,0 +1,111 @@
+(function () {
+  'use strict';
+
+  const ROUTE_NAME = 'menu.vehiclePartsPainting';
+  const ROUTE_PATH = '/vehicle-parts-painting';
+  const ROUTE_DEFINITION = {
+    path: ROUTE_PATH,
+    name: ROUTE_NAME,
+    meta: {
+      topBar: { visible: true },
+      uiApps: { shown: true },
+      infoBar: { withAngular: true, visible: false, showSysInfo: false },
+      clickThrough: true
+    }
+  };
+
+  const TRANSLATIONS = {
+    'en-US': {
+      vehiclePartsPainting: {
+        topbarLabel: 'Vehicle Parts Painting'
+      }
+    }
+  };
+
+  function mergeTranslations() {
+    if (!window.vueI18n || !window.vueI18n.global || typeof window.vueI18n.global.mergeLocaleMessage !== 'function') {
+      return false;
+    }
+
+    try {
+      Object.keys(TRANSLATIONS).forEach(locale => {
+        window.vueI18n.global.mergeLocaleMessage(locale, TRANSLATIONS[locale]);
+      });
+
+      const currentLocale = window.vueI18n.global.locale && window.vueI18n.global.locale.value;
+      if (currentLocale && !TRANSLATIONS[currentLocale]) {
+        window.vueI18n.global.mergeLocaleMessage(currentLocale, TRANSLATIONS['en-US']);
+      }
+      return true;
+    } catch (err) {
+      console.error('VehiclePartsPainting: failed to merge translations', err);
+    }
+    return false;
+  }
+
+  function getRouter() {
+    if (window.bngVue && window.bngVue.router) {
+      return window.bngVue.router;
+    }
+    if (window.$router) {
+      return window.$router;
+    }
+    return null;
+  }
+
+  function registerRoute() {
+    const router = getRouter();
+    if (!router || typeof router.addRoute !== 'function') {
+      return false;
+    }
+
+    try {
+      if (window.bngVue && !window.bngVue.router) {
+        window.bngVue.router = router;
+      }
+      if (typeof router.hasRoute === 'function') {
+        if (router.hasRoute(ROUTE_NAME)) { return true; }
+      }
+      router.addRoute(ROUTE_DEFINITION);
+      return true;
+    } catch (err) {
+      console.error('VehiclePartsPainting: failed to register Vue route', err);
+    }
+    return false;
+  }
+
+  function attemptIntegration() {
+    const merged = mergeTranslations();
+    const routed = registerRoute();
+    return merged && routed;
+  }
+
+  function scheduleIntegration() {
+    if (attemptIntegration()) {
+      return;
+    }
+
+    let retries = 0;
+    const timer = window.setInterval(function () {
+      retries += 1;
+      if (attemptIntegration() || retries > 30) {
+        window.clearInterval(timer);
+      }
+    }, 500);
+  }
+
+  if (window.bngVue && typeof window.bngVue.start === 'function') {
+    const originalStart = window.bngVue.start;
+    window.bngVue.start = function (...args) {
+      const result = originalStart.apply(this, args);
+      window.setTimeout(scheduleIntegration, 0);
+      return result;
+    };
+  }
+
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    scheduleIntegration();
+  } else {
+    window.addEventListener('DOMContentLoaded', scheduleIntegration, { once: true });
+  }
+})();


### PR DESCRIPTION
## Summary
- add a Lua helper extension that registers the Vehicle Parts Painting app in the Freeroam top bar and cleans it up when unloaded
- add an Angular Freeroam state so the app can be opened from the top bar and forwards lifecycle notifications to Lua
- bridge the Vue layer with top bar metadata and translations so the new button displays with the expected label

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca963f36f08329a1e2aa45fcea9024