### PR TITLE
Fix user palette clearing after base paint changes

### DIFF
--- a/.tests/vehiclePartsPainting.test.js
+++ b/.tests/vehiclePartsPainting.test.js
@@ -510,6 +510,16 @@ function resetPaint(scope, partPath) {
   let palettePreset = state.colorPresets[0];
   assert.strictEqual(palettePreset.storageIndex, 1, 'Preset should retain its storage index');
 
+  scope.basePaintEditors[0].color.r = 32;
+  scope.basePaintEditors[0].color.g = 64;
+  scope.applyBasePaints();
+  scope.$digest();
+
+  const repaintState = cloneStateForEvent(scope);
+  repaintState.colorPresets = null;
+  emitState(scope, repaintState);
+  assert(Array.isArray(state.colorPresets) && state.colorPresets.length === 1, 'Color presets should persist when payload omits presets via null placeholder');
+
   const invalidPalettePayload = cloneStateForEvent(scope);
   invalidPalettePayload.colorPresets = { length: 1, n: 1 };
   emitState(scope, invalidPalettePayload);

--- a/.tests/vehiclePartsPainting.test.js
+++ b/.tests/vehiclePartsPainting.test.js
@@ -544,6 +544,17 @@ function resetPaint(scope, partPath) {
   assert.strictEqual(palettePreset.name, 'Lua style swatch', 'Lua-style payload should preserve preset names');
   assert(Math.abs(palettePreset.paint.metallic - 0.1) < 1e-6, 'Lua-style payload should preserve numeric fields');
 
+  const placeholderPaletteAfterBaseApply = cloneStateForEvent(scope);
+  placeholderPaletteAfterBaseApply.colorPresets = [];
+  emitState(scope, placeholderPaletteAfterBaseApply);
+  assert(Array.isArray(state.colorPresets) && state.colorPresets.length === 1, 'Color presets should persist when base paint updates omit presets via empty array placeholder');
+
+  applyCustomPaint(scope, 'vehicle/root', { r: 64 });
+  const placeholderPaletteAfterPartApply = cloneStateForEvent(scope);
+  placeholderPaletteAfterPartApply.colorPresets = [];
+  emitState(scope, placeholderPaletteAfterPartApply);
+  assert(Array.isArray(state.colorPresets) && state.colorPresets.length === 1, 'Color presets should persist when part repaint updates omit presets via empty array placeholder');
+
   scope.onPresetPressStart({}, palettePreset);
   controller.timeout.flush();
   assert(state.removePresetDialog.visible === true, 'Holding a preset should display removal dialog');
@@ -553,6 +564,7 @@ function resetPaint(scope, partPath) {
   scope.confirmRemovePreset();
   assert.strictEqual(state.removePresetDialog.visible, false, 'Removal dialog should close after confirmation');
   assert.strictEqual(bngApiCalls.length, commandCountBeforeRemove + 1, 'Removing a preset should queue a backend command');
+  assert(Array.isArray(state.colorPresets) && state.colorPresets.length === 0, 'Color presets should clear locally after removing the last preset');
   const removeCommand = bngApiCalls[bngApiCalls.length - 1];
   const remainingPresets = parseSettingsSetStateCommand(removeCommand);
   assert(Array.isArray(remainingPresets) && remainingPresets.length === 0, 'Removing a preset should clear stored presets');

--- a/ui/modules/apps/vehiclePartsPainting/app.js
+++ b/ui/modules/apps/vehiclePartsPainting/app.js
@@ -442,10 +442,9 @@ angular.module('beamng.apps')
       function updateColorPresets(rawPresets) {
         if (rawPresets === undefined) { return; }
         if (rawPresets === null) {
-          state.colorPresets = [];
-          if (state.removePresetDialog.visible) {
-            closeRemovePresetDialog();
-          }
+          // Some state refresh payloads omit preset data by sending null. Keep the
+          // existing palette in that case so previously loaded swatches remain
+          // available to the user until a concrete update arrives.
           return;
         }
         if (typeof rawPresets === 'string') {

--- a/ui/modules/apps/vehiclePartsPainting/app.js
+++ b/ui/modules/apps/vehiclePartsPainting/app.js
@@ -323,6 +323,35 @@ angular.module('beamng.apps')
         return [];
       }
 
+      function convertPresetTableToArray(value) {
+        if (!value || typeof value !== 'object') { return null; }
+        if (Array.isArray(value)) { return value; }
+        const keys = Object.keys(value);
+        if (!keys.length) { return []; }
+        const array = [];
+        let hasNumericKey = false;
+        for (let i = 0; i < keys.length; i++) {
+          const key = keys[i];
+          if (key === 'length' || key === 'n') { continue; }
+          if (!/^[0-9]+$/.test(key)) { continue; }
+          const index = parseInt(key, 10);
+          if (!isFinite(index) || index < 1) { continue; }
+          array[index - 1] = value[key];
+          hasNumericKey = true;
+        }
+        if (!hasNumericKey) {
+          const length = typeof value.length === 'number' ? value.length : null;
+          const nValue = typeof value.n === 'number' ? value.n : null;
+          if ((length !== null && length <= 0) || (nValue !== null && nValue <= 0)) { return []; }
+          return null;
+        }
+        for (let i = array.length - 1; i >= 0; i--) {
+          if (array[i] !== undefined) { break; }
+          array.pop();
+        }
+        return array;
+      }
+
       function cloneSanitizedPresets(presets) {
         const sanitizedList = [];
         if (!Array.isArray(presets)) { return sanitizedList; }
@@ -399,6 +428,12 @@ angular.module('beamng.apps')
       function updateColorPresets(rawPresets) {
         if (typeof rawPresets === 'string') {
           rawPresets = decodeSettingsPresetArray(rawPresets);
+        }
+        if (!Array.isArray(rawPresets)) {
+          const converted = convertPresetTableToArray(rawPresets);
+          if (Array.isArray(converted)) {
+            rawPresets = converted;
+          }
         }
         if (!Array.isArray(rawPresets)) {
           state.colorPresets = [];

--- a/ui/modules/apps/vehiclePartsPainting/app.js
+++ b/ui/modules/apps/vehiclePartsPainting/app.js
@@ -439,7 +439,9 @@ angular.module('beamng.apps')
         return null;
       }
 
-      function updateColorPresets(rawPresets) {
+      function updateColorPresets(rawPresets, options) {
+        options = options || {};
+        const preserveExistingOnEmpty = options && options.preserveExistingOnEmpty === true;
         if (rawPresets === undefined) { return; }
         if (rawPresets === null) {
           // Some state refresh payloads omit preset data by sending null. Keep the
@@ -474,6 +476,12 @@ angular.module('beamng.apps')
           if (preset) {
             preset.storageIndex = presets.length + 1;
             presets.push(preset);
+          }
+        }
+        if (!presets.length && preserveExistingOnEmpty) {
+          const hasExisting = Array.isArray(state.colorPresets) && state.colorPresets.length > 0;
+          if (hasExisting) {
+            return;
           }
         }
         state.colorPresets = presets;
@@ -2078,7 +2086,7 @@ angular.module('beamng.apps')
           state.vehicleId = data.vehicleId || null;
 
           if (Object.prototype.hasOwnProperty.call(data, 'colorPresets')) {
-            updateColorPresets(data.colorPresets);
+            updateColorPresets(data.colorPresets, { preserveExistingOnEmpty: true });
           }
 
           if (!state.vehicleId) {


### PR DESCRIPTION
## Summary
- normalize preset data received from Lua tables before updating the user palette
- avoid wiping the palette when base paint updates send array-like objects

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caa6def27483298775c1e56e0ea085