### PR TITLE
Add saved config previews and deletion flow

### DIFF
--- a/.tests/vehiclePartsPainting.test.js
+++ b/.tests/vehiclePartsPainting.test.js
@@ -513,6 +513,42 @@ function resetPaint(scope, partPath) {
   };
   assert(scope.canDeleteSavedConfig(originUserConfig), 'Configurations marked with a user origin should be deletable');
 
+  const numericUserFlagConfig = {
+    relativePath: 'vehicles/example/config_e.pc',
+    displayName: 'Config Epsilon',
+    isUserConfig: 1
+  };
+  assert(scope.canDeleteSavedConfig(numericUserFlagConfig), 'Numeric truthy isUserConfig values should be interpreted as deletable user configs');
+
+  const stringUserFlagConfig = {
+    relativePath: 'vehicles/example/config_f.pc',
+    displayName: 'Config Zeta',
+    userConfig: 'TRUE'
+  };
+  assert(scope.canDeleteSavedConfig(stringUserFlagConfig), 'String truthy userConfig values should allow deletion');
+
+  const localPathConfig = {
+    relativePath: 'vehicles/example/config_g.pc',
+    displayName: 'Config Eta',
+    absolutePath: '/local/vehicles/example/config_g.pc'
+  };
+  assert(scope.canDeleteSavedConfig(localPathConfig), 'Configs stored under the /local namespace should be deletable');
+
+  const appDataPathConfig = {
+    relativePath: 'vehicles/example/config_h.pc',
+    displayName: 'Config Theta',
+    absolutePath: 'C:/Users/ok/AppData/Local/BeamNG.drive/current/vehicles/example/config_h.pc'
+  };
+  assert(scope.canDeleteSavedConfig(appDataPathConfig), 'Configs stored under the AppData BeamNG.drive directory should be deletable');
+
+  const explicitNonUserConfig = {
+    relativePath: 'vehicles/example/config_i.pc',
+    displayName: 'Config Iota',
+    isUserConfig: 'false',
+    allowDelete: 'false'
+  };
+  assert(!scope.canDeleteSavedConfig(explicitNonUserConfig), 'Explicit non-user flags should prevent deletion');
+
   scope.promptDeleteSavedConfig(stockConfig);
   assert.strictEqual(state.deleteConfigDialog.visible, false, 'Delete dialog should ignore non-deletable configurations');
 

--- a/.tests/vehiclePartsPainting.test.js
+++ b/.tests/vehiclePartsPainting.test.js
@@ -498,6 +498,21 @@ function resetPaint(scope, partPath) {
   assert(scope.canDeleteSavedConfig(userConfig), 'User configuration should be deletable');
   assert(!scope.canDeleteSavedConfig(stockConfig), 'Non-user configuration should not expose deletion');
 
+  const userPathConfig = {
+    relativePath: 'vehicles/example/config_c.pc',
+    displayName: 'Config Gamma',
+    allowDelete: false,
+    userFilePath: 'C:/Users/test/AppData/Local/BeamNG.drive/latest/vehicles/example/config_c.pc'
+  };
+  assert(scope.canDeleteSavedConfig(userPathConfig), 'User configuration with a user file path should be deletable even if flagged otherwise');
+
+  const originUserConfig = {
+    relativePath: 'vehicles/example/config_d.pc',
+    displayName: 'Config Delta',
+    origin: 'USER'
+  };
+  assert(scope.canDeleteSavedConfig(originUserConfig), 'Configurations marked with a user origin should be deletable');
+
   scope.promptDeleteSavedConfig(stockConfig);
   assert.strictEqual(state.deleteConfigDialog.visible, false, 'Delete dialog should ignore non-deletable configurations');
 

--- a/.tests/vehiclePartsPainting.test.js
+++ b/.tests/vehiclePartsPainting.test.js
@@ -492,7 +492,8 @@ function resetPaint(scope, partPath) {
 
   assert(scope.hasSavedConfigPreview(userConfig), 'User configuration should report an available preview');
   const previewSrc = scope.getSavedConfigPreviewSrc(userConfig);
-  assert(typeof previewSrc === 'string' && previewSrc.includes('config_a'), 'Preview URL should reference the configuration file name');
+  assert.strictEqual(previewSrc, '/vehicles/example/config_a.png', 'Preview URL should resolve to the vehicle resource path');
+  assert(previewSrc.indexOf('/local/') === -1, 'Preview URL should not include the /local prefix');
   assert(!scope.hasSavedConfigPreview(stockConfig), 'Config without preview should return false from helper');
   assert(scope.canDeleteSavedConfig(userConfig), 'User configuration should be deletable');
   assert(!scope.canDeleteSavedConfig(stockConfig), 'Non-user configuration should not expose deletion');
@@ -503,6 +504,7 @@ function resetPaint(scope, partPath) {
   scope.promptDeleteSavedConfig(userConfig);
   assert.strictEqual(state.deleteConfigDialog.visible, true, 'Delete dialog should appear for deletable configurations');
   assert(state.deleteConfigDialog.config && state.deleteConfigDialog.config.relativePath === userConfig.relativePath, 'Delete dialog should target the selected configuration');
+  assert(scope.hasSavedConfigPreview(state.deleteConfigDialog.config), 'Delete dialog should surface the configuration preview');
   assert.strictEqual(state.deleteConfigDialog.isDeleting, false, 'Delete dialog should start idle');
 
   scope.cancelDeleteSavedConfig();

--- a/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
+++ b/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
@@ -1154,13 +1154,38 @@ local function deleteSavedConfiguration(configPath)
   end
 
   local targetDir = (userVehiclesDir .. modelFolder .. '/'):gsub('\\', '/')
+  local relativeConfigPath = normalized
   local configFilePath = targetDir .. baseName .. '.pc'
-  local removedConfig = removeFileIfExists(configFilePath)
+  local removalTargets = { configFilePath, relativeConfigPath }
+  local seenTargets = {}
+  local removedConfig = false
+  for _, candidate in ipairs(removalTargets) do
+    if candidate and candidate ~= '' then
+      local key = candidate
+      if not seenTargets[key] then
+        seenTargets[key] = true
+        if removeFileIfExists(candidate) then
+          removedConfig = true
+        end
+      end
+    end
+  end
+
   local removedPreview = false
+  local previewSeen = {}
   for _, extension in ipairs(previewImageExtensions) do
-    local previewPath = targetDir .. baseName .. extension
-    if removeFileIfExists(previewPath) then
-      removedPreview = true
+    local previewRelative = string.format('vehicles/%s/%s%s', modelFolder, baseName, extension)
+    local previewAbsolute = targetDir .. baseName .. extension
+    local previewTargets = { previewAbsolute, previewRelative }
+    for _, candidate in ipairs(previewTargets) do
+      if candidate and candidate ~= '' then
+        if not previewSeen[candidate] then
+          previewSeen[candidate] = true
+          if removeFileIfExists(candidate) then
+            removedPreview = true
+          end
+        end
+      end
     end
   end
 

--- a/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
+++ b/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
@@ -765,6 +765,7 @@ local function gatherSavedConfigsFromDisk(modelFolder)
       visitedRoots[root] = true
       local okFind, files = safePcall(FS.findFiles, FS, root, '*.pc', 0, false, true)
       if okFind and type(files) == 'table' then
+        local isUserRoot = (targetDir ~= nil and root == targetDir)
         for _, filePath in ipairs(files) do
           if type(filePath) == 'string' and filePath ~= '' then
             local normalizedPath = filePath:gsub('\\', '/')
@@ -780,7 +781,11 @@ local function gatherSavedConfigsFromDisk(modelFolder)
                 local isAbsolute = normalizedPath:match('^%a:/') or normalizedPath:sub(1, 1) == '/'
                 local userFilePath = nil
                 local userFileExists = false
-                if targetDir then
+
+                if isUserRoot then
+                  userFileExists = true
+                  userFilePath = normalizedPath
+                elseif targetDir then
                   local candidate = targetDir .. fileName .. '.pc'
                   local okUser, hasUser = safePcall(FS.fileExists, FS, candidate)
                   if okUser and hasUser then
@@ -806,6 +811,8 @@ local function gatherSavedConfigsFromDisk(modelFolder)
 
                 if userFileExists and userFilePath then
                   entry.userFilePath = userFilePath
+                  entry.allowDelete = true
+                  entry.isDeletable = true
                 end
 
                 local previewRelative = nil

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beamng_free_mode_inventory",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "scripts": {
     "test": "node .tests/vehiclePartsPainting.test.js"

--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -1557,11 +1557,11 @@
                   <div class="saved-name">{{getSavedConfigLabel(config)}}</div>
                   <div class="saved-meta">{{config.relativePath}}</div>
                 </div>
-                <div class="saved-actions">
+                <div class="saved-actions" ng-if="canDeleteSavedConfig(config)">
                   <button type="button"
                           class="delete-button"
                           ng-click="promptDeleteSavedConfig(config); $event.stopPropagation();"
-                          ng-disabled="!canDeleteSavedConfig(config) || (state.deleteConfigDialog.isDeleting && state.deleteConfigDialog.config && state.deleteConfigDialog.config.relativePath === config.relativePath)">
+                          ng-disabled="state.deleteConfigDialog.isDeleting && state.deleteConfigDialog.config && state.deleteConfigDialog.config.relativePath === config.relativePath">
                     Delete
                   </button>
                 </div>

--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -403,8 +403,17 @@
       border-radius: 3px;
     }
     .vehicle-parts-painting .parts-panel .panel-header .panel-actions button.orange {
+      width: 24px;
+      height: 24px;
+      padding: 2px;
+    }
+    .vehicle-parts-painting .parts-panel .panel-header .panel-actions button:hover {
       border: 1px solid #ff6600;
       color: #ff6600;
+    }
+    .vehicle-parts-painting .parts-panel .panel-header .panel-actions button.orange svg {
+      width: 90%;
+      height: 90%;
     }
     .vehicle-parts-painting .filter-field {
       padding: 8px 10px;
@@ -588,11 +597,14 @@
       flex: 0 0 auto;
       padding: 6px 12px;
       border-radius: 4px;
-      border: 1px solid rgba(255, 255, 255, 0.35);
-      background: rgba(0, 170, 255, 0.85);
+      border: none;
+      background: #ff6600;
       color: #fff;
       font-weight: 600;
       font-size: 12px;
+    }
+    .vehicle-parts-painting .config-tools .config-actions button:hover {
+      background: #ff7d26;
     }
     .vehicle-parts-painting .config-tools .config-actions button:disabled {
       opacity: 0.5;
@@ -1191,12 +1203,24 @@
       color: #fff;
       border-radius: 4px;
     }
+    .vehicle-parts-painting .editor-actions .primary:hover {
+      background: #ff7d26;
+      border: none;
+      padding: 8px 14px;
+      font-weight: 600;
+      color: #fff;
+      border-radius: 4px;
+    }
     .vehicle-parts-painting .editor-actions .secondary {
-      background: transparent;
-      border: 1px solid rgba(255, 255, 255, 0.3);
+      background: #333333;
+      border: none;
       color: inherit;
       padding: 8px 14px;
       border-radius: 4px;
+    }
+    .vehicle-parts-painting .editor-actions .secondary:hover {
+      border: none;
+      background: #4c4c4c;
     }
     @media (min-width: 640px) {
       .vehicle-parts-painting .color-picker-dialog .picker-content {
@@ -1453,7 +1477,7 @@
   </div>
   <div class="app-content" ng-if="!state.minimized">
     <div class="app-header">
-      <h2>Vehicle Parts Painting</h2>
+      <h2>Vehicle Parts Painting <span style="font-style: italic; font-size: 10px; opacity: 0.5; margin-left: 2em;">version 1.0.3, made by KRtekTM</span></h2>
       <div class="header-actions">
         <button type="button" ng-click="refresh()">Refresh</button>
         <button type="button" ng-click="minimizeApp()">Minimize</button>
@@ -1465,11 +1489,16 @@
     <div class="app-body" ng-if="state.vehicleId">
       <div class="parts-panel">
       <div class="panel-header">
-        <div><span>Vehicle Parts Selector</span></div>
+        <div style="margin-bottom: 6px;"><span>Vehicle Parts Selector</span></div>
         <div class="panel-actions">
           <button type="button" ng-click="collapseAllNodes()">Collapse all</button>
           <button type="button" ng-click="expandAllNodes()">Expand all</button>
-          <button type="button" ng-click="showAllParts()" class="orange">Show whole vehicle</button>
+          <button type="button" ng-click="showAllParts()" class="orange">
+            <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+              <path d="M0 0h24v24H0z" fill="none"/>
+              <path d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z" fill="#ff6600"/>
+            </svg>
+          </button>
         </div>
       </div>
       <div class="filter-field">

--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -1270,7 +1270,7 @@
         <button type="button"
                 class="danger"
                 ng-click="confirmDeleteSavedConfig()"
-                ng-disabled="state.deleteConfigDialog.isDeleting">Delete</button>
+                ng-disabled="state.deleteConfigDialog.isDeleting">Confirm Delete</button>
         <button type="button"
                 class="cancel"
                 ng-click="cancelDeleteSavedConfig()"

--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -92,6 +92,49 @@
       justify-content: flex-end;
       gap: 10px;
     }
+    .vehicle-parts-painting .config-confirm-dialog .config-target {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 10px 12px;
+      border-radius: 6px;
+      background: rgba(255, 255, 255, 0.06);
+    }
+    .vehicle-parts-painting .config-confirm-dialog .config-target .config-target-preview {
+      flex: 0 0 auto;
+      width: 120px;
+      height: 72px;
+      border-radius: 4px;
+      overflow: hidden;
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      background: rgba(0, 0, 0, 0.45);
+    }
+    .vehicle-parts-painting .config-confirm-dialog .config-target .config-target-preview img {
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+    .vehicle-parts-painting .config-confirm-dialog .config-target .config-target-details {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      min-width: 0;
+    }
+    .vehicle-parts-painting .config-confirm-dialog .config-target .config-target-name {
+      font-size: 15px;
+      font-weight: 600;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .vehicle-parts-painting .config-confirm-dialog .config-target .config-target-meta {
+      font-size: 12px;
+      opacity: 0.75;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
     .vehicle-parts-painting .config-confirm-dialog .dialog-actions button,
     .vehicle-parts-painting .palette-dialog .dialog-actions button,
     .vehicle-parts-painting .color-picker-dialog .dialog-actions button {
@@ -1207,14 +1250,22 @@
   <div class="config-confirm-overlay" ng-if="state.deleteConfigDialog.visible">
     <div class="config-confirm-dialog">
       <h4>Delete saved configuration?</h4>
-      <p>
-        Are you sure you want to delete
-        "{{state.deleteConfigDialog.config ? getSavedConfigLabel(state.deleteConfigDialog.config) : ''}}"?
-      </p>
-      <p class="file-hint"
-         ng-if="state.deleteConfigDialog.config && state.deleteConfigDialog.config.relativePath">
-        File: {{state.deleteConfigDialog.config.relativePath}}
-      </p>
+      <p>Are you sure you want to delete this configuration?</p>
+      <div class="config-target"
+           ng-if="state.deleteConfigDialog.config">
+        <div class="config-target-preview"
+             ng-if="hasSavedConfigPreview(state.deleteConfigDialog.config)">
+          <img ng-src="{{getSavedConfigPreviewSrc(state.deleteConfigDialog.config)}}"
+               ng-attr-alt="{{getSavedConfigLabel(state.deleteConfigDialog.config)}} preview">
+        </div>
+        <div class="config-target-details">
+          <div class="config-target-name">{{getSavedConfigLabel(state.deleteConfigDialog.config)}}</div>
+          <div class="config-target-meta"
+               ng-if="state.deleteConfigDialog.config.relativePath">
+            File: {{state.deleteConfigDialog.config.relativePath}}
+          </div>
+        </div>
+      </div>
       <div class="dialog-actions">
         <button type="button"
                 class="danger"
@@ -1506,11 +1557,11 @@
                   <div class="saved-name">{{getSavedConfigLabel(config)}}</div>
                   <div class="saved-meta">{{config.relativePath}}</div>
                 </div>
-                <div class="saved-actions" ng-if="canDeleteSavedConfig(config)">
+                <div class="saved-actions">
                   <button type="button"
                           class="delete-button"
                           ng-click="promptDeleteSavedConfig(config); $event.stopPropagation();"
-                          ng-disabled="state.deleteConfigDialog.isDeleting && state.deleteConfigDialog.config && state.deleteConfigDialog.config.relativePath === config.relativePath">
+                          ng-disabled="!canDeleteSavedConfig(config) || (state.deleteConfigDialog.isDeleting && state.deleteConfigDialog.config && state.deleteConfigDialog.config.relativePath === config.relativePath)">
                     Delete
                   </button>
                 </div>

--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -101,12 +101,25 @@
       font-weight: 600;
       border: none;
     }
+    .vehicle-parts-painting .config-confirm-dialog .dialog-actions button:disabled,
+    .vehicle-parts-painting .palette-dialog .dialog-actions button:disabled,
+    .vehicle-parts-painting .color-picker-dialog .dialog-actions button:disabled {
+      opacity: 0.6;
+      cursor: default;
+    }
     .vehicle-parts-painting .config-confirm-dialog .dialog-actions .confirm {
       background: rgba(0, 170, 255, 0.9);
       color: #fff;
     }
     .vehicle-parts-painting .config-confirm-dialog .dialog-actions .confirm:hover {
       background: rgba(0, 170, 255, 1);
+    }
+    .vehicle-parts-painting .config-confirm-dialog .dialog-actions .danger {
+      background: rgba(234, 80, 71, 0.92);
+      color: #fff;
+    }
+    .vehicle-parts-painting .config-confirm-dialog .dialog-actions .danger:hover {
+      background: rgba(234, 80, 71, 1);
     }
     .vehicle-parts-painting .config-confirm-dialog .dialog-actions .cancel,
     .vehicle-parts-painting .palette-dialog .dialog-actions .cancel,
@@ -556,7 +569,7 @@
     .vehicle-parts-painting .config-tools .saved-item {
       display: flex;
       align-items: center;
-      justify-content: space-between;
+      justify-content: flex-start;
       gap: 10px;
       padding: 6px 8px;
       border-radius: 4px;
@@ -570,11 +583,27 @@
     .vehicle-parts-painting .config-tools .saved-item.selected {
       background: rgba(0, 170, 255, 0.35);
     }
+    .vehicle-parts-painting .config-tools .saved-preview {
+      flex: 0 0 auto;
+      width: 60px;
+      height: 36px;
+      border-radius: 4px;
+      overflow: hidden;
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      background: rgba(0, 0, 0, 0.45);
+    }
+    .vehicle-parts-painting .config-tools .saved-preview img {
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
     .vehicle-parts-painting .config-tools .saved-details {
       display: flex;
       flex-direction: column;
       gap: 2px;
       min-width: 0;
+      flex: 1;
     }
     .vehicle-parts-painting .config-tools .saved-name {
       font-size: 13px;
@@ -590,13 +619,28 @@
       overflow: hidden;
       text-overflow: ellipsis;
     }
-    .vehicle-parts-painting .config-tools .saved-actions button {
-      background: transparent;
-      border: 1px solid rgba(255, 255, 255, 0.45);
-      color: inherit;
-      padding: 4px 8px;
+    .vehicle-parts-painting .config-tools .saved-actions {
+      flex: 0 0 auto;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-left: auto;
+    }
+    .vehicle-parts-painting .config-tools .saved-actions .delete-button {
+      background: rgba(234, 80, 71, 0.9);
+      border: none;
+      color: #fff;
+      padding: 4px 10px;
       border-radius: 4px;
-      font-size: 12px;
+      font-size: 11px;
+      font-weight: 600;
+    }
+    .vehicle-parts-painting .config-tools .saved-actions .delete-button:hover {
+      background: rgba(234, 80, 71, 1);
+    }
+    .vehicle-parts-painting .config-tools .saved-actions .delete-button:disabled {
+      opacity: 0.6;
+      cursor: default;
     }
     .vehicle-parts-painting .config-tools .config-footer {
       display: flex;
@@ -1160,6 +1204,29 @@
       </div>
     </div>
   </div>
+  <div class="config-confirm-overlay" ng-if="state.deleteConfigDialog.visible">
+    <div class="config-confirm-dialog">
+      <h4>Delete saved configuration?</h4>
+      <p>
+        Are you sure you want to delete
+        "{{state.deleteConfigDialog.config ? getSavedConfigLabel(state.deleteConfigDialog.config) : ''}}"?
+      </p>
+      <p class="file-hint"
+         ng-if="state.deleteConfigDialog.config && state.deleteConfigDialog.config.relativePath">
+        File: {{state.deleteConfigDialog.config.relativePath}}
+      </p>
+      <div class="dialog-actions">
+        <button type="button"
+                class="danger"
+                ng-click="confirmDeleteSavedConfig()"
+                ng-disabled="state.deleteConfigDialog.isDeleting">Delete</button>
+        <button type="button"
+                class="cancel"
+                ng-click="cancelDeleteSavedConfig()"
+                ng-disabled="state.deleteConfigDialog.isDeleting">Cancel</button>
+      </div>
+    </div>
+  </div>
   <div class="palette-dialog-overlay" ng-if="state.removePresetDialog.visible">
     <div class="palette-dialog">
       <h4>Delete color from palette?</h4>
@@ -1431,15 +1498,22 @@
                     ng-repeat="config in getSavedConfigs() track by config.relativePath"
                     ng-class="{selected: isSavedConfigSelected(config)}"
                     ng-click="selectSavedConfig(config)">
+                <div class="saved-preview" ng-if="hasSavedConfigPreview(config)">
+                  <img ng-src="{{getSavedConfigPreviewSrc(config)}}"
+                       ng-attr-alt="{{getSavedConfigLabel(config)}} preview">
+                </div>
                 <div class="saved-details">
                   <div class="saved-name">{{getSavedConfigLabel(config)}}</div>
                   <div class="saved-meta">{{config.relativePath}}</div>
                 </div>
-                <!--<div class="saved-actions">
+                <div class="saved-actions" ng-if="canDeleteSavedConfig(config)">
                   <button type="button"
-                          ng-click="spawnSavedConfiguration(config); $event.stopPropagation();"
-                          ng-disabled="true">Spawn</button>
-                </div>-->
+                          class="delete-button"
+                          ng-click="promptDeleteSavedConfig(config); $event.stopPropagation();"
+                          ng-disabled="state.deleteConfigDialog.isDeleting && state.deleteConfigDialog.config && state.deleteConfigDialog.config.relativePath === config.relativePath">
+                    Delete
+                  </button>
+                </div>
               </div>
             </div>
             <div class="saved-empty" ng-if="!hasSavedConfigs()">No saved configurations for this vehicle yet.</div>

--- a/ui/modules/apps/vehiclePartsPainting/app.js
+++ b/ui/modules/apps/vehiclePartsPainting/app.js
@@ -766,7 +766,7 @@ angular.module('beamng.apps')
           return normalized;
         }
 
-        return '/local/' + normalized.replace(/^\/+/, '');
+        return '/' + normalized.replace(/^\/+/, '');
       }
 
       function hasConfigPreview(config) {

--- a/ui/modules/apps/vehiclePartsPainting/app.js
+++ b/ui/modules/apps/vehiclePartsPainting/app.js
@@ -771,11 +771,6 @@ angular.module('beamng.apps')
         return null;
       }
 
-      function normalizePathCandidate(value) {
-        if (typeof value !== 'string') { return ''; }
-        return value.replace(/\\+/g, '/').trim().toLowerCase();
-      }
-
       function buildConfigPreviewSrc(path) {
         if (typeof path !== 'string') { return null; }
         let normalized = path.trim();
@@ -808,55 +803,42 @@ angular.module('beamng.apps')
       function isConfigDeletable(config) {
         if (!config || typeof config !== 'object') { return false; }
 
-        const userFilePathRaw = (typeof config.userFilePath === 'string') ? config.userFilePath.trim() : '';
-        const absolutePathRaw = (typeof config.absolutePath === 'string') ? config.absolutePath.trim() : '';
-        const relativePathRaw = (typeof config.relativePath === 'string') ? config.relativePath.trim() : '';
-        const origin = (typeof config.origin === 'string') ? config.origin.trim().toLowerCase() : '';
-        const source = (typeof config.source === 'string') ? config.source.trim().toLowerCase() : '';
-        const fileSource = (typeof config.fileSource === 'string') ? config.fileSource.trim().toLowerCase() : '';
-        const pathType = (typeof config.pathType === 'string') ? config.pathType.trim().toLowerCase() : '';
-        const location = (typeof config.location === 'string') ? config.location.trim().toLowerCase() : '';
-        const storage = (typeof config.storage === 'string') ? config.storage.trim().toLowerCase() : '';
-        const root = (typeof config.root === 'string') ? config.root.trim().toLowerCase() : '';
-
         const allowDeleteFlag = coerceBooleanFlag(config.allowDelete);
         const deletableFlag = coerceBooleanFlag(config.isDeletable);
-
-        const userFlag = coerceBooleanFlag(config.isUserConfig, ['user', 'local']);
-        const legacyUserFlag = coerceBooleanFlag(config.userConfig, ['user', 'local']);
-        const localFlag = coerceBooleanFlag(config.local, ['user', 'local']);
-        const userPropertyFlag = coerceBooleanFlag(config.user, ['user']);
-
-        const isExplicitUser = [userFlag, legacyUserFlag, localFlag, userPropertyFlag]
-          .some(function (value) { return value === true; });
-        const isExplicitNonUser = [userFlag, legacyUserFlag, localFlag, userPropertyFlag]
-          .some(function (value) { return value === false; });
-
-        const isUserByOrigin = [origin, source, fileSource, pathType, location, storage, root]
-          .some(function (value) { return value === 'user' || value === 'local'; });
-
-        const normalizedPaths = [userFilePathRaw, absolutePathRaw, relativePathRaw]
-          .map(function (value) { return normalizePathCandidate(value); })
-          .filter(function (value) { return !!value; });
-
-        const isUserByPath = normalizedPaths.some(function (path) {
-          if (path.indexOf('/local/') === 0) { return true; }
-          if (path.indexOf('beamng.drive/') !== -1) { return true; }
-          if (path.indexOf('/appdata/') !== -1) { return true; }
-          if (path.indexOf('/users/') !== -1) { return true; }
-          return false;
-        });
-
-        if (userFilePathRaw || isExplicitUser || isUserByOrigin || isUserByPath) {
-          return true;
-        }
-
-        if (allowDeleteFlag === false || deletableFlag === false || isExplicitNonUser) {
+        if (allowDeleteFlag === false || deletableFlag === false) {
           return false;
         }
 
-        if (allowDeleteFlag === true || deletableFlag === true) {
+        const playerFlag = coerceBooleanFlag(config.player, ['player', 'user', 'local']);
+        if (playerFlag === true) {
           return true;
+        }
+        if (playerFlag === false) {
+          return false;
+        }
+
+        const userFlag = coerceBooleanFlag(config.isUserConfig, ['player', 'user', 'local']);
+        if (userFlag === true) {
+          return true;
+        }
+        if (userFlag === false) {
+          return false;
+        }
+
+        const legacyUserFlag = coerceBooleanFlag(config.userConfig, ['player', 'user', 'local']);
+        if (legacyUserFlag === true) {
+          return true;
+        }
+        if (legacyUserFlag === false) {
+          return false;
+        }
+
+        const userPropertyFlag = coerceBooleanFlag(config.user, ['player', 'user', 'local']);
+        if (userPropertyFlag === true) {
+          return true;
+        }
+        if (userPropertyFlag === false) {
+          return false;
         }
 
         return false;

--- a/ui/modules/apps/vehiclePartsPainting/app.js
+++ b/ui/modules/apps/vehiclePartsPainting/app.js
@@ -776,11 +776,20 @@ angular.module('beamng.apps')
 
       function isConfigDeletable(config) {
         if (!config || typeof config !== 'object') { return false; }
+
+        const userFilePath = (typeof config.userFilePath === 'string') ? config.userFilePath.trim() : '';
+        const origin = (typeof config.origin === 'string') ? config.origin.trim().toLowerCase() : '';
+        const source = (typeof config.source === 'string') ? config.source.trim().toLowerCase() : '';
+        const fileSource = (typeof config.fileSource === 'string') ? config.fileSource.trim().toLowerCase() : '';
+        const isExplicitUser = config.isUserConfig === true || config.userConfig === true || config.local === true;
+        const isUserByOrigin = origin === 'user' || source === 'user' || fileSource === 'user';
+        if (isExplicitUser || isUserByOrigin || userFilePath) { return true; }
+
         if (config.allowDelete === false) { return false; }
-        if (config.isUserConfig === false) { return false; }
         if (config.isDeletable === false) { return false; }
-        if (config.isUserConfig === true || config.isDeletable === true) { return true; }
-        if (config.userFilePath && typeof config.userFilePath === 'string' && config.userFilePath.trim()) { return true; }
+        if (config.isUserConfig === false || config.userConfig === false || config.local === false) { return false; }
+        if (config.allowDelete === true || config.isDeletable === true) { return true; }
+
         return false;
       }
 

--- a/ui/modules/apps/vehiclePartsPainting/app.json
+++ b/ui/modules/apps/vehiclePartsPainting/app.json
@@ -1,7 +1,7 @@
 {
   "name": "Vehicle Parts Painting",
   "author": "KRtekTM",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Customize paint for individual vehicle parts while in Freeroam.",
   "directive": "vehiclePartsPainting",
   "domElement": "<vehicle-parts-painting></vehicle-parts-painting>",


### PR DESCRIPTION
## Summary
- show saved configuration preview thumbnails with delete controls in the UI
- add front-end handling for deletable configs, preview URLs, and delete confirmation
- extend the backend to surface preview metadata and remove saved configurations and thumbnails
- cover the new behaviour with automated tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cacd8a95b08329b7883748c362dda4