### PR TITLE
Add Vehicle Livery Editor launcher to parts painting app

### DIFF
--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -1480,6 +1480,7 @@
       <h2>Vehicle Parts Painting <span style="font-style: italic; font-size: 10px; opacity: 0.5; margin-left: 2em;">version 1.0.3, made by KRtekTM</span></h2>
       <div class="header-actions">
         <button type="button" ng-click="refresh()">Refresh</button>
+        <button type="button" ng-click="openLiveryEditor()">Open Vehicle Livery Editor</button>
         <button type="button" ng-click="minimizeApp()">Minimize</button>
       </div>
     </div>

--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -299,6 +299,10 @@
     .vehicle-parts-painting .app-header .header-actions button:hover {
       border-color: rgba(255, 255, 255, 0.6);
     }
+    .vehicle-parts-painting .app-header .header-actions button:disabled {
+      opacity: 0.5;
+      cursor: default;
+    }
     .vehicle-parts-painting .minimized-bar {
       display: none;
       width: 100%;
@@ -1489,7 +1493,11 @@
     <div class="app-header">
       <h2>Vehicle Parts Painting <span style="font-style: italic; font-size: 10px; opacity: 0.5; margin-left: 2em;">version 1.0.3, made by KRtekTM</span></h2>
       <div class="header-actions">
-        <button type="button" ng-click="refresh()">Refresh</button>
+        <button type="button" ng-click="refresh()">
+          <svg width="12px" height="12px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M12 9V6C8.69 6 6 8.69 6 12C6 13.01 6.25 13.97 6.7 14.8L5.24 16.26C4.46 15.03 4 13.57 4 12C4 7.58 7.58 4 12 4V1L16 5L12 9ZM17.3 9.2L18.76 7.74C19.54 8.97 20 10.43 20 12C20 16.42 16.42 20 12 20V23L8 19L12 15V18C15.31 18 18 15.31 18 12C18 10.99 17.74 10.04 17.3 9.2Z" fill="#ffffff"/>
+          </svg>
+        </button>
         <button type="button"
                 ng-if="state.vehicleId && state.liveryEditorSupported !== null"
                 ng-click="state.liveryEditorSupported && openLiveryEditor()"

--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -1251,6 +1251,16 @@
       }
     }
   </style>
+  <div class="config-confirm-overlay" ng-if="state.liveryEditorConfirmation.visible">
+    <div class="config-confirm-dialog">
+      <h4>Vehicle Livery Editor</h4>
+      <p>{{liveryEditorConfirmationText}}</p>
+      <div class="dialog-actions">
+        <button type="button" class="confirm" ng-click="confirmLiveryEditorLaunch()">Open Vehicle Livery Editor</button>
+        <button type="button" class="cancel" ng-click="cancelLiveryEditorLaunch()">Cancel</button>
+      </div>
+    </div>
+  </div>
   <div class="config-confirm-overlay" ng-if="state.showReplaceConfirmation">
     <div class="config-confirm-dialog">
       <h4>

--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -1490,7 +1490,12 @@
       <h2>Vehicle Parts Painting <span style="font-style: italic; font-size: 10px; opacity: 0.5; margin-left: 2em;">version 1.0.3, made by KRtekTM</span></h2>
       <div class="header-actions">
         <button type="button" ng-click="refresh()">Refresh</button>
-        <button type="button" ng-click="openLiveryEditor()">Open Vehicle Livery Editor</button>
+        <button type="button"
+                ng-if="state.vehicleId && state.liveryEditorSupported !== null"
+                ng-click="state.liveryEditorSupported && openLiveryEditor()"
+                ng-disabled="!state.liveryEditorSupported">
+          {{ state.liveryEditorSupported ? 'Open Vehicle Livery Editor' : 'Vehicle Livery Editor is not available for this vehicle' }}
+        </button>
         <button type="button" ng-click="minimizeApp()">Minimize</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a Vehicle Livery Editor action button to the vehicle parts painting app header
- implement UI messaging, capability probing, and confirmation flow before navigating to the livery manager
- extend tests to stub engine Lua callbacks and verify livery editor launch behavior and failure messaging

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caecf910688329a06cc56fae8908a7