### PR TITLE
Add fallback preview image for saved configs

### DIFF
--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -1291,8 +1291,7 @@
       <p>Are you sure you want to delete this configuration?</p>
       <div class="config-target"
            ng-if="state.deleteConfigDialog.config">
-        <div class="config-target-preview"
-             ng-if="hasSavedConfigPreview(state.deleteConfigDialog.config)">
+        <div class="config-target-preview">
           <img ng-src="{{getSavedConfigPreviewSrc(state.deleteConfigDialog.config)}}"
                ng-attr-alt="{{getSavedConfigLabel(state.deleteConfigDialog.config)}} preview">
         </div>
@@ -1602,7 +1601,7 @@
                     ng-repeat="config in getSavedConfigs() track by config.relativePath"
                     ng-class="{selected: isSavedConfigSelected(config)}"
                     ng-click="selectSavedConfig(config)">
-                <div class="saved-preview" ng-if="hasSavedConfigPreview(config)">
+                <div class="saved-preview">
                   <img ng-src="{{getSavedConfigPreviewSrc(config)}}"
                        ng-attr-alt="{{getSavedConfigLabel(config)}} preview">
                 </div>

--- a/ui/modules/apps/vehiclePartsPainting/app.js
+++ b/ui/modules/apps/vehiclePartsPainting/app.js
@@ -110,6 +110,8 @@ angular.module('beamng.apps')
       const LIVERY_EDITOR_UNSUPPORTED_MESSAGE = 'Vehicle Livery Editor is not available for this vehicle.';
       const LIVERY_EDITOR_MESSAGE_CATEGORY = 'vehiclePartsPainting';
 
+      const DEFAULT_CONFIG_PREVIEW_IMAGE = 'ui/modules/apps/vehiclePartsPainting/missing-preview.png';
+
       $scope.liveryEditorConfirmationText = LIVERY_EDITOR_CONFIRMATION_TEXT;
 
       const CUSTOM_BADGE_REFRESH_INTERVAL_MS = 750;
@@ -904,6 +906,12 @@ end)()`;
       function hasConfigPreview(config) {
         if (!config || typeof config !== 'object') { return false; }
         return typeof config.previewImage === 'string' && config.previewImage.trim() !== '';
+      }
+
+      function resolveConfigPreviewPath(config) {
+        if (!config || typeof config !== 'object') { return null; }
+        if (hasConfigPreview(config)) { return config.previewImage; }
+        return DEFAULT_CONFIG_PREVIEW_IMAGE;
       }
 
       function isConfigDeletable(config) {
@@ -2248,8 +2256,9 @@ end)()`;
       };
 
       $scope.getSavedConfigPreviewSrc = function (config) {
-        if (!hasConfigPreview(config)) { return null; }
-        return buildConfigPreviewSrc(config.previewImage);
+        const path = resolveConfigPreviewPath(config);
+        if (!path) { return null; }
+        return buildConfigPreviewSrc(path);
       };
 
       $scope.canDeleteSavedConfig = function (config) {


### PR DESCRIPTION
## Summary
- add a default saved configuration preview constant and helper to fall back to the placeholder image when a config lacks its own screenshot
- update the saved configurations list and delete confirmation dialog to always render a preview image via the fallback source

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb0f6775f88329b002d5cad035ff31