### PR TITLE
Fix vehicle parts filter debounce handling

### DIFF
--- a/.tests/vehiclePartsPainting.test.js
+++ b/.tests/vehiclePartsPainting.test.js
@@ -388,6 +388,9 @@ function resetPaint(scope, partPath) {
 
 function setFilterText(scope, controller, value, options) {
   scope.state.filterText = value;
+  if (typeof scope.onFilterInputChanged === 'function') {
+    scope.onFilterInputChanged();
+  }
   scope.$digest();
   if (!options || options.flush !== false) {
     controller.timeout.flush();
@@ -457,6 +460,37 @@ function setFilterText(scope, controller, value, options) {
   setFilterText(scope, controller, 'door');
   let filteredDoor = findNode(state.filteredTree, 'vehicle/door');
   assert(filteredDoor && filteredDoor.part && filteredDoor.part.partPath === 'vehicle/door', 'Filtering after cancelling debounce should still work');
+  let missingHood = findNode(state.filteredTree, 'vehicle/hood');
+  assert.strictEqual(missingHood, null, 'Filtering for door should hide hood nodes');
+
+  setFilterText(scope, controller, 'do');
+  filteredDoor = findNode(state.filteredTree, 'vehicle/door');
+  assert(filteredDoor && filteredDoor.part && filteredDoor.part.partPath === 'vehicle/door', 'Partial filter updates should keep matching parts visible');
+  missingHood = findNode(state.filteredTree, 'vehicle/hood');
+  assert.strictEqual(missingHood, null, 'Partial filter narrowing should continue to exclude unmatched parts');
+
+  setFilterText(scope, controller, '');
+  node = findNode(state.filteredTree, 'vehicle/hood');
+  assert(node && node.part && node.part.partPath === 'vehicle/hood', 'Clearing the filter via typing should restore hood to the tree');
+  filteredDoor = findNode(state.filteredTree, 'vehicle/door');
+  assert(filteredDoor && filteredDoor.part && filteredDoor.part.partPath === 'vehicle/door', 'Clearing the filter via typing should restore door to the tree');
+
+  setFilterText(scope, controller, 'hood');
+  let filteredHood = findNode(state.filteredTree, 'vehicle/hood');
+  assert(filteredHood && filteredHood.part && filteredHood.part.partPath === 'vehicle/hood', 'Filtering for hood after clearing should work repeatedly');
+  filteredDoor = findNode(state.filteredTree, 'vehicle/door');
+  assert.strictEqual(filteredDoor, null, 'Filtering for hood should hide door parts');
+
+  setFilterText(scope, controller, 'hoo');
+  filteredHood = findNode(state.filteredTree, 'vehicle/hood');
+  assert(filteredHood && filteredHood.part && filteredHood.part.partPath === 'vehicle/hood', 'Editing the filter text should keep matches up to date');
+
+  setFilterText(scope, controller, '');
+  node = findNode(state.filteredTree, 'vehicle/hood');
+  assert(node && node.part && node.part.partPath === 'vehicle/hood', 'Clearing the filter again should restore hood to the tree');
+  filteredDoor = findNode(state.filteredTree, 'vehicle/door');
+  assert(filteredDoor && filteredDoor.part && filteredDoor.part.partPath === 'vehicle/door', 'Clearing the filter again should restore door to the tree');
+
   scope.clearFilter();
   scope.$digest();
   controller.timeout.flush();

--- a/.tests/vehiclePartsPainting.test.js
+++ b/.tests/vehiclePartsPainting.test.js
@@ -511,6 +511,21 @@ function setFilterText(scope, controller, value, options) {
   filteredHood = findNode(state.filteredTree, 'vehicle/hood');
   assert.strictEqual(filteredHood, null, 'Filtering for door after clearing without the change hook should hide hood nodes');
 
+  setFilterText(scope, controller, 'door');
+  filteredDoor = findNode(state.filteredTree, 'vehicle/door');
+  assert(filteredDoor && filteredDoor.part && filteredDoor.part.partPath === 'vehicle/door', 'Filtering for door should isolate the matching part');
+  setFilterText(scope, controller, 'd', { flush: false });
+  let hoodAfterBackspace = findNode(state.filteredTree, 'vehicle/hood');
+  assert(hoodAfterBackspace && hoodAfterBackspace.part && hoodAfterBackspace.part.partPath === 'vehicle/hood', 'Backspacing the filter should immediately restore hood before the debounce flush');
+  let doorAfterBackspace = findNode(state.filteredTree, 'vehicle/door');
+  assert(doorAfterBackspace && doorAfterBackspace.part && doorAfterBackspace.part.partPath === 'vehicle/door', 'Backspacing the filter should keep door visible without waiting for debounce');
+  assert.strictEqual(state.filteredParts.length, parts.length, 'Broadening the filter should expand the matching parts immediately');
+  controller.timeout.flush();
+  hoodAfterBackspace = findNode(state.filteredTree, 'vehicle/hood');
+  assert(hoodAfterBackspace && hoodAfterBackspace.part && hoodAfterBackspace.part.partPath === 'vehicle/hood', 'Debounce flush after broadening should retain hood visibility');
+  doorAfterBackspace = findNode(state.filteredTree, 'vehicle/door');
+  assert(doorAfterBackspace && doorAfterBackspace.part && doorAfterBackspace.part.partPath === 'vehicle/door', 'Debounce flush after broadening should retain door visibility');
+
   scope.clearFilter();
   scope.$digest();
   controller.timeout.flush();

--- a/.tests/vehiclePartsPainting.test.js
+++ b/.tests/vehiclePartsPainting.test.js
@@ -453,6 +453,12 @@ function triggerFilterSearch(controller, value) {
   controller.filterInput.trigger('search');
 }
 
+function triggerFilterInput(controller, value) {
+  assert(controller && controller.filterInput, 'Filter input stub not available');
+  controller.filterInput.value = value;
+  controller.filterInput.trigger('input');
+}
+
 (function runTests() {
   const controller = instantiateController();
   const scope = controller.scope;
@@ -650,6 +656,61 @@ function triggerFilterSearch(controller, value) {
   assert(doorNode && doorNode.part && doorNode.part.partPath === 'vehicle/door', 'Second search event clear should restore the door node');
   filteredBumper = findNode(state.filteredTree, 'vehicle/bumper_front');
   assert(filteredBumper && filteredBumper.part && filteredBumper.part.partPath === 'vehicle/bumper_front', 'Second search event clear should restore the bumper node');
+
+  triggerFilterSearch(controller, 'bumper');
+  scope.$digest();
+  filteredBumper = findNode(state.filteredTree, 'vehicle/bumper_front');
+  assert(filteredBumper && filteredBumper.part && filteredBumper.part.partPath === 'vehicle/bumper_front', 'Input handling should start from a filtered bumper node');
+  filteredDoor = findNode(state.filteredTree, 'vehicle/door');
+  assert.strictEqual(filteredDoor, null, 'Input handling scenario should begin with the door hidden');
+
+  triggerFilterInput(controller, '');
+  scope.$digest();
+  node = findNode(state.filteredTree, 'vehicle/root');
+  assert(node && node.part && node.part.partPath === 'vehicle/root', 'Input events should restore the root node after clearing');
+  filteredDoor = findNode(state.filteredTree, 'vehicle/door');
+  assert(filteredDoor && filteredDoor.part && filteredDoor.part.partPath === 'vehicle/door', 'Input events should restore door parts after clearing');
+  filteredBumper = findNode(state.filteredTree, 'vehicle/bumper_front');
+  assert(filteredBumper && filteredBumper.part && filteredBumper.part.partPath === 'vehicle/bumper_front', 'Input events should restore bumper parts after clearing');
+
+  triggerFilterInput(controller, 'doo');
+  scope.$digest();
+  filteredDoor = findNode(state.filteredTree, 'vehicle/door');
+  assert(filteredDoor && filteredDoor.part && filteredDoor.part.partPath === 'vehicle/door', 'Typing after search should filter the door part');
+  filteredBumper = findNode(state.filteredTree, 'vehicle/bumper_front');
+  assert.strictEqual(filteredBumper, null, 'Typing after search should hide the bumper');
+
+  triggerFilterInput(controller, 'd');
+  scope.$digest();
+  filteredDoor = findNode(state.filteredTree, 'vehicle/door');
+  assert(filteredDoor && filteredDoor.part && filteredDoor.part.partPath === 'vehicle/door', 'Broadening the input filter should keep matching door parts visible');
+  filteredBumper = findNode(state.filteredTree, 'vehicle/bumper_front');
+  assert(filteredBumper && filteredBumper.part && filteredBumper.part.partPath === 'vehicle/bumper_front', 'Broadening the input filter should restore bumper nodes that match the broader query');
+
+  triggerFilterInput(controller, '');
+  scope.$digest();
+  node = findNode(state.filteredTree, 'vehicle/root');
+  assert(node && node.part && node.part.partPath === 'vehicle/root', 'Clearing via input should restore the root part');
+  filteredDoor = findNode(state.filteredTree, 'vehicle/door');
+  assert(filteredDoor && filteredDoor.part && filteredDoor.part.partPath === 'vehicle/door', 'Clearing via input should restore door nodes');
+  filteredBumper = findNode(state.filteredTree, 'vehicle/bumper_front');
+  assert(filteredBumper && filteredBumper.part && filteredBumper.part.partPath === 'vehicle/bumper_front', 'Clearing via input should restore bumper nodes');
+
+  triggerFilterInput(controller, 'hood');
+  scope.$digest();
+  filteredHood = findNode(state.filteredTree, 'vehicle/hood');
+  assert(filteredHood && filteredHood.part && filteredHood.part.partPath === 'vehicle/hood', 'Typing after clearing should filter the hood part');
+  filteredDoor = findNode(state.filteredTree, 'vehicle/door');
+  assert.strictEqual(filteredDoor, null, 'Typing after clearing should hide door nodes');
+
+  triggerFilterInput(controller, '');
+  scope.$digest();
+  node = findNode(state.filteredTree, 'vehicle/root');
+  assert(node && node.part && node.part.partPath === 'vehicle/root', 'Clearing input again should restore the full tree');
+  filteredDoor = findNode(state.filteredTree, 'vehicle/door');
+  assert(filteredDoor && filteredDoor.part && filteredDoor.part.partPath === 'vehicle/door', 'Clearing input again should restore the door node');
+  filteredBumper = findNode(state.filteredTree, 'vehicle/bumper_front');
+  assert(filteredBumper && filteredBumper.part && filteredBumper.part.partPath === 'vehicle/bumper_front', 'Clearing input again should restore the bumper node');
 
   const customMap = hooks.getCustomPaintState();
   customMap['vehicle/door'] = true;

--- a/.tests/vehiclePartsPainting.test.js
+++ b/.tests/vehiclePartsPainting.test.js
@@ -419,7 +419,8 @@ function setFilterText(scope, controller, value, options) {
   const parts = [
     createPart('vehicle/root', 'body', basePaints),
     createPart('vehicle/hood', 'body/hood', basePaints),
-    createPart('vehicle/door', 'body/door', basePaints)
+    createPart('vehicle/door', 'body/door', basePaints),
+    createPart('vehicle/bumper_front', 'body/bumper', basePaints)
   ];
 
   emitState(scope, {
@@ -526,9 +527,62 @@ function setFilterText(scope, controller, value, options) {
   doorAfterBackspace = findNode(state.filteredTree, 'vehicle/door');
   assert(doorAfterBackspace && doorAfterBackspace.part && doorAfterBackspace.part.partPath === 'vehicle/door', 'Debounce flush after broadening should retain door visibility');
 
+  setFilterText(scope, controller, 'bumper');
+  let filteredBumper = findNode(state.filteredTree, 'vehicle/bumper_front');
+  assert(filteredBumper && filteredBumper.part && filteredBumper.part.partPath === 'vehicle/bumper_front', 'Filtering for bumper should isolate the bumper part');
+  let missingDoorAfterBumperFilter = findNode(state.filteredTree, 'vehicle/door');
+  assert.strictEqual(missingDoorAfterBumperFilter, null, 'Filtering for bumper should hide door parts');
+
+  scope.onFilterInputChanged();
+  scope.$digest();
+  controller.timeout.flush();
+
+  filteredBumper = findNode(state.filteredTree, 'vehicle/bumper_front');
+  assert(filteredBumper && filteredBumper.part && filteredBumper.part.partPath === 'vehicle/bumper_front', 'Confirming the bumper filter should keep the bumper visible');
+
+  setFilterText(scope, controller, 'bumpe');
+  filteredBumper = findNode(state.filteredTree, 'vehicle/bumper_front');
+  assert(filteredBumper && filteredBumper.part && filteredBumper.part.partPath === 'vehicle/bumper_front', 'Editing the bumper filter should keep the bumper node visible');
+  let missingHoodAfterEdit = findNode(state.filteredTree, 'vehicle/hood');
+  assert.strictEqual(missingHoodAfterEdit, null, 'Editing the bumper filter should continue hiding hood parts');
+
+  setFilterText(scope, controller, 'bump');
+  filteredBumper = findNode(state.filteredTree, 'vehicle/bumper_front');
+  assert(filteredBumper && filteredBumper.part && filteredBumper.part.partPath === 'vehicle/bumper_front', 'Broadening the bumper filter should retain the bumper node');
+
   scope.clearFilter();
   scope.$digest();
   controller.timeout.flush();
+
+  filteredBumper = findNode(state.filteredTree, 'vehicle/bumper_front');
+  assert(filteredBumper && filteredBumper.part && filteredBumper.part.partPath === 'vehicle/bumper_front', 'Clearing the filter should restore the bumper node to the tree');
+  node = findNode(state.filteredTree, 'vehicle/hood');
+  assert(node && node.part && node.part.partPath === 'vehicle/hood', 'Clearing the filter should restore the hood node to the tree');
+  doorNode = findNode(state.filteredTree, 'vehicle/door');
+  assert(doorNode && doorNode.part && doorNode.part.partPath === 'vehicle/door', 'Clearing the filter should restore the door node to the tree');
+
+  setFilterText(scope, controller, 'door');
+  filteredDoor = findNode(state.filteredTree, 'vehicle/door');
+  assert(filteredDoor && filteredDoor.part && filteredDoor.part.partPath === 'vehicle/door', 'Filtering for door after confirming search should still isolate the door part');
+  filteredBumper = findNode(state.filteredTree, 'vehicle/bumper_front');
+  assert.strictEqual(filteredBumper, null, 'Filtering for door after confirming search should hide bumper parts');
+
+  setFilterText(scope, controller, '');
+  filteredBumper = findNode(state.filteredTree, 'vehicle/bumper_front');
+  assert(filteredBumper && filteredBumper.part && filteredBumper.part.partPath === 'vehicle/bumper_front', 'Clearing the filter after refiltering should restore the bumper node');
+
+  setFilterText(scope, controller, 'door');
+  scope.state.filterText = 'd';
+  scope.onFilterInputChanged();
+  scope.state.filterText = '';
+  scope.$digest();
+  controller.timeout.flush();
+  assert.strictEqual(state.filterText, '', 'Programmatic filter reset should leave the search box empty');
+  filteredDoor = findNode(state.filteredTree, 'vehicle/door');
+  assert(filteredDoor && filteredDoor.part && filteredDoor.part.partPath === 'vehicle/door', 'Programmatic filter reset should restore the door node');
+  filteredBumper = findNode(state.filteredTree, 'vehicle/bumper_front');
+  assert(filteredBumper && filteredBumper.part && filteredBumper.part.partPath === 'vehicle/bumper_front', 'Programmatic filter reset should restore the bumper node');
+
   const customMap = hooks.getCustomPaintState();
   customMap['vehicle/door'] = true;
   scope.$digest();

--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -1528,7 +1528,6 @@
         <input type="search"
                 placeholder="Search parts..."
                 ng-model="state.filterText"
-                ng-model-options="{ debounce: 150 }"
                 autocomplete="off">
         <button type="button"
                 class="clear-filter"

--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -1528,6 +1528,7 @@
         <input type="search"
                 placeholder="Search parts..."
                 ng-model="state.filterText"
+                ng-change="onFilterInputChanged()"
                 autocomplete="off">
         <button type="button"
                 class="clear-filter"

--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -1528,7 +1528,6 @@
         <input type="search"
                 placeholder="Search parts..."
                 ng-model="state.filterText"
-                ng-change="onFilterInputChanged()"
                 autocomplete="off">
         <button type="button"
                 class="clear-filter"

--- a/ui/modules/apps/vehiclePartsPainting/app.js
+++ b/ui/modules/apps/vehiclePartsPainting/app.js
@@ -1806,9 +1806,9 @@ end)()`;
         }, FILTER_DEBOUNCE_DELAY_MS);
       }
 
-      $scope.$watch(function () { return state.filterText; }, function () {
+      $scope.onFilterInputChanged = function () {
         scheduleFilteredPartsRecompute();
-      });
+      };
 
       $scope.onColorChannelChanged = function (paint) {
         sanitizeColor(paint);

--- a/ui/modules/apps/vehiclePartsPainting/app.js
+++ b/ui/modules/apps/vehiclePartsPainting/app.js
@@ -1805,7 +1805,7 @@ end)()`;
       }
 
       let lastFilterTextValue = state.filterText;
-      let filterChangeHandledByHook = false;
+      let filterChangeHandledByHookValue = null;
 
       function scheduleFilteredPartsRecompute(options) {
         options = options || {};
@@ -1837,8 +1837,8 @@ end)()`;
       $scope.$watch(function () { return state.filterText; }, function (newValue, oldValue) {
         if (newValue === oldValue) { return; }
         const shouldImmediate = shouldRecomputeFilterImmediately(oldValue, newValue);
-        const handledByHook = shouldImmediate && filterChangeHandledByHook;
-        filterChangeHandledByHook = false;
+        const handledByHook = shouldImmediate && filterChangeHandledByHookValue === newValue;
+        filterChangeHandledByHookValue = null;
         if (!handledByHook) {
           if (shouldImmediate) {
             scheduleFilteredPartsRecompute({ immediate: true });
@@ -1853,7 +1853,7 @@ end)()`;
         const previousValue = lastFilterTextValue;
         const currentValue = state.filterText;
         const shouldImmediate = shouldRecomputeFilterImmediately(previousValue, currentValue);
-        filterChangeHandledByHook = shouldImmediate;
+        filterChangeHandledByHookValue = shouldImmediate ? currentValue : null;
         if (shouldImmediate) {
           scheduleFilteredPartsRecompute({ immediate: true });
         } else {


### PR DESCRIPTION
## Summary
- replace the Angular model debounce with an explicit `$timeout` scheduler to prevent stale filter updates and cancel pending runs when parts state changes
- trigger immediate filter recomputes when clearing the search box or performing paint operations and cancel pending timers during teardown
- remove the `ng-model-options` debounce from the filter input and add unit coverage for clearing the filter before the debounce flushes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb211d38b083299a3f070db00f02df