### PR TITLE
Fix base paint persistence and update reset behavior

### DIFF
--- a/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
+++ b/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
@@ -1826,6 +1826,8 @@ end
 
 local sendState
 local applyStoredPaints
+local getBasePaintState
+local getVehicleBasePaints
 
 local function setVehicleBasePaints(paints)
   local vehObj = getPlayerVehicle(0)
@@ -1881,7 +1883,7 @@ local function setVehicleBasePaintsJson(jsonStr)
   setVehicleBasePaints(paints)
 end
 
-local function getBasePaintState(vehId, create)
+getBasePaintState = function(vehId, create)
   if not vehId then return nil end
   local state = basePaintStateByVeh[vehId]
   if not state and create then
@@ -1891,7 +1893,7 @@ local function getBasePaintState(vehId, create)
   return state
 end
 
-local function getVehicleBasePaints(vehId, vehData, vehObj)
+getVehicleBasePaints = function(vehId, vehData, vehObj)
   local state = getBasePaintState(vehId, false)
   if state and type(state.current) == 'table' and not tableIsEmpty(state.current) then
     return copyPaints(state.current)

--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -1665,8 +1665,8 @@
               </div>
             </div>
             <div class="editor-actions">
-              <button type="button" class="primary" ng-click="applyBasePaints()" ng-disabled="!basePaintEditors.length || !hasBasePaintChanges()">Apply base paint</button>
-              <button type="button" class="secondary" ng-click="resetBasePaintEditors()" ng-disabled="!basePaintEditors.length || !hasBasePaintChanges()">Revert changes</button>
+              <button type="button" class="primary" ng-click="applyBasePaints()">Apply base color</button>
+              <button type="button" class="secondary" ng-click="resetBasePaintEditors()">Reset base color</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- keep per-vehicle base paint state so part repainting respects the last applied base colors and expose original paints to the UI
- update the vehicle paint UI to always enable base color actions, remember original colors for reset, and adjust button labels
- extend the automated tests to cover the base-color-change then part-repaint scenario and the reset workflow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb5b9d89e88329b822b5de76a071de