### PR TITLE
Adjust minimized icon alignment based on widget position

### DIFF
--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -1,4 +1,6 @@
-<div class="vehicle-parts-painting" ng-class="{'is-minimized': state.minimized}">
+<div class="vehicle-parts-painting"
+     ng-class="{'is-minimized': state.minimized, 'is-minimized-align-right': state.minimized && state.minimizedAlignment === 'right'}"
+     ng-style="state.minimizedInlineStyle">
   <style>
     .vehicle-parts-painting {
       width: 100%;


### PR DESCRIPTION
## Summary
- align the minimized icon to the right edge when the widget sits mostly on the right half of the viewport
- track minimized alignment state and inline transform inside the Angular controller
- extend the node-based UI tests with coverage for the minimize/restore alignment logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb72f1fc948329890273a75e2c4c88