### PR TITLE
Synchronize finish sliders with numeric inputs

### DIFF
--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -1410,29 +1410,69 @@
               <div class="finish-field">
                 <label>Metallic</label>
                 <div class="field-row">
-                  <input type="range" min="0" max="1" step="0.01" ng-model="colorPickerState.working.metallic">
-                  <input type="number" min="0" max="1" step="0.01" ng-model="colorPickerState.working.metallic">
+                  <input type="range"
+                         min="0"
+                         max="1"
+                         step="0.01"
+                         ng-model="colorPickerState.working.metallic"
+                         ng-change="onFinishValueChanged(colorPickerState.working, 'metallic')">
+                  <input type="number"
+                         min="0"
+                         max="1"
+                         step="0.01"
+                         ng-model="colorPickerState.working.metallic"
+                         ng-change="onFinishValueChanged(colorPickerState.working, 'metallic')">
                 </div>
               </div>
               <div class="finish-field">
                 <label>Roughness</label>
                 <div class="field-row">
-                  <input type="range" min="0" max="1" step="0.01" ng-model="colorPickerState.working.roughness">
-                  <input type="number" min="0" max="1" step="0.01" ng-model="colorPickerState.working.roughness">
+                  <input type="range"
+                         min="0"
+                         max="1"
+                         step="0.01"
+                         ng-model="colorPickerState.working.roughness"
+                         ng-change="onFinishValueChanged(colorPickerState.working, 'roughness')">
+                  <input type="number"
+                         min="0"
+                         max="1"
+                         step="0.01"
+                         ng-model="colorPickerState.working.roughness"
+                         ng-change="onFinishValueChanged(colorPickerState.working, 'roughness')">
                 </div>
               </div>
               <div class="finish-field">
                 <label>Clearcoat</label>
                 <div class="field-row">
-                  <input type="range" min="0" max="1" step="0.01" ng-model="colorPickerState.working.clearcoat">
-                  <input type="number" min="0" max="1" step="0.01" ng-model="colorPickerState.working.clearcoat">
+                  <input type="range"
+                         min="0"
+                         max="1"
+                         step="0.01"
+                         ng-model="colorPickerState.working.clearcoat"
+                         ng-change="onFinishValueChanged(colorPickerState.working, 'clearcoat')">
+                  <input type="number"
+                         min="0"
+                         max="1"
+                         step="0.01"
+                         ng-model="colorPickerState.working.clearcoat"
+                         ng-change="onFinishValueChanged(colorPickerState.working, 'clearcoat')">
                 </div>
               </div>
               <div class="finish-field">
                 <label>Clearcoat Roughness</label>
                 <div class="field-row">
-                  <input type="range" min="0" max="1" step="0.01" ng-model="colorPickerState.working.clearcoatRoughness">
-                  <input type="number" min="0" max="1" step="0.01" ng-model="colorPickerState.working.clearcoatRoughness">
+                  <input type="range"
+                         min="0"
+                         max="1"
+                         step="0.01"
+                         ng-model="colorPickerState.working.clearcoatRoughness"
+                         ng-change="onFinishValueChanged(colorPickerState.working, 'clearcoatRoughness')">
+                  <input type="number"
+                         min="0"
+                         max="1"
+                         step="0.01"
+                         ng-model="colorPickerState.working.clearcoatRoughness"
+                         ng-change="onFinishValueChanged(colorPickerState.working, 'clearcoatRoughness')">
                 </div>
               </div>
             </div>

--- a/ui/modules/apps/vehiclePartsPainting/app.js
+++ b/ui/modules/apps/vehiclePartsPainting/app.js
@@ -285,6 +285,14 @@ angular.module('beamng.apps')
         return color;
       }
 
+      function sanitizeFinishProperty(paint, key) {
+        if (!paint || !key) { return; }
+        const normalized = Math.round(clamp01(paint[key]) * 100) / 100;
+        if (paint[key] !== normalized) {
+          paint[key] = normalized;
+        }
+      }
+
       function createPickerWorkingPaint(paint) {
         if (!paint) { return null; }
         const working = angular.copy(paint);
@@ -1843,6 +1851,10 @@ end)()`;
         if (colorPickerState.working === paint) {
           syncActiveHsvFromWorking();
         }
+      };
+
+      $scope.onFinishValueChanged = function (paint, key) {
+        sanitizeFinishProperty(paint, key);
       };
 
       $scope.onHtmlColorInputChanged = function (paint) {


### PR DESCRIPTION
## Summary
- add change handlers to finish sliders and numeric inputs in the color picker so both stay in sync
- sanitize finish values by clamping and rounding when a slider or numeric input is adjusted

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb8505b1ec8329a09510e225372016