### PR TITLE
Add pull request test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: Tests
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    name: Node Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Run test suite
+        run: npm test
+        continue-on-error: true
+
+      - name: Report test results
+        if: always()
+        uses: dorny/test-reporter@v1
+        with:
+          name: Node.js Test Results
+          path: .reports/junit.xml
+          reporter: java-junit

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 krtektm_freeroamPartInventory.zip
+.reports/

--- a/.tests/run-tests.js
+++ b/.tests/run-tests.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+
+function xmlEscape(value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function wrapCdata(value) {
+  return `<![CDATA[${value.replace(/\]\]>/g, ']]]]><![CDATA[>')}]]>`;
+}
+
+const start = process.hrtime.bigint();
+let failure = null;
+
+try {
+  require(path.join(__dirname, 'vehiclePartsPainting.test.js'));
+} catch (error) {
+  failure = error instanceof Error ? error : new Error(String(error));
+}
+
+const durationSeconds = Number(process.hrtime.bigint() - start) / 1e9;
+const reportsDir = path.resolve(__dirname, '../.reports');
+fs.mkdirSync(reportsDir, { recursive: true });
+
+const suiteName = 'vehiclePartsPainting';
+const testName = 'vehiclePartsPainting';
+const timestamp = new Date().toISOString();
+
+const timeString = durationSeconds.toFixed(3);
+const failureCount = failure ? 1 : 0;
+
+let testCaseXml = `    <testcase classname="${suiteName}" name="${testName}" time="${timeString}">`;
+if (failure) {
+  const message = xmlEscape(failure.message || 'Test execution failed');
+  const details = wrapCdata(failure.stack || String(failure));
+  testCaseXml += `\n      <failure message="${message}">${details}</failure>\n    </testcase>`;
+} else {
+  testCaseXml += '</testcase>';
+}
+
+const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<testsuites>\n  <testsuite name="${suiteName}" tests="1" failures="${failureCount}" errors="0" skipped="0" timestamp="${timestamp}" time="${timeString}">\n${testCaseXml}\n  </testsuite>\n</testsuites>\n`;
+
+fs.writeFileSync(path.join(reportsDir, 'junit.xml'), xml, 'utf8');
+
+if (failure) {
+  console.error(failure.stack || failure.message || failure);
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "1.1.1",
   "private": true,
   "scripts": {
-    "test": "node .tests/vehiclePartsPainting.test.js"
+    "test": "node .tests/run-tests.js"
   }
 }


### PR DESCRIPTION
## Summary
- add a pull-request GitHub Actions workflow that runs the test suite and reports results via the Test Reporter action
- create a Node-based test runner that executes the existing tests and emits JUnit output for CI consumption
- ignore the generated test report directory and update the npm test script to use the new runner

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc7d5932f083298b92c5df7fcebc0a