### PR TITLE
Replace tree filter with searchable parts list

### DIFF
--- a/.tests/vehiclePartsPainting.test.js
+++ b/.tests/vehiclePartsPainting.test.js
@@ -536,6 +536,8 @@ function resetPaint(scope, partPath) {
   const initialTreeSnapshot = JSON.stringify(state.filteredTree);
   assert.strictEqual(state.filteringActive, false, 'Filtering should be inactive by default');
   assert(Array.isArray(state.filterResults) && state.filterResults.length === 0, 'Initial filter results should be empty');
+  assert.strictEqual(typeof scope.areTreeControlsDisabled, 'function', 'Tree control helper should be exposed on scope');
+  assert.strictEqual(scope.areTreeControlsDisabled(), false, 'Tree controls should start enabled before filtering');
 
   scope.state.filterText = 'b';
   scope.$digest();
@@ -545,6 +547,7 @@ function resetPaint(scope, partPath) {
   assert.strictEqual(expectedMatches.length, 5, 'Single-letter search should find five matching parts for b');
   assert.strictEqual(state.filteredParts.length, expectedMatches.length, 'Single-letter search should include expected matches');
   assert.strictEqual(state.filterResults.length, expectedMatches.length, 'Filtered list should mirror filtered parts count');
+  assert.strictEqual(scope.areTreeControlsDisabled(), true, 'Tree controls should disable while filtering is active');
 
   const rootFilteredEntry = state.filterResults.find(function (entry) { return entry.part.partPath === 'vehicle/root'; });
   assert(rootFilteredEntry && rootFilteredEntry.slotSegments.some(function (segment) {
@@ -613,6 +616,7 @@ function resetPaint(scope, partPath) {
     if (term) {
       assert.strictEqual(state.filteringActive, true, 'Partial query "' + term + '" should keep filtering active');
       assert.strictEqual(state.filterResults.length, expectedLength, 'Filtered list should refresh for "' + term + '"');
+      assert.strictEqual(scope.areTreeControlsDisabled(), true, 'Tree controls should stay disabled during query "' + term + '"');
       if (term === 'bum' && bumperLastWord) {
         const bumperEntry = state.filterResults.find(function (entry) { return entry.part.partPath === 'vehicle/front_bumper'; });
         assert(bumperEntry && Array.isArray(bumperEntry.nameWordSegments) && bumperEntry.nameWordSegments.length,
@@ -653,6 +657,7 @@ function resetPaint(scope, partPath) {
       assert.strictEqual(state.filteringActive, false, 'Clearing the search should disable filtering');
       assert.strictEqual(state.filterResults.length, 0, 'Clearing the search should hide the filtered list');
       assert.strictEqual(state.filteredParts.length, scope.state.parts.length, 'Clearing the search should restore the full part list');
+      assert.strictEqual(scope.areTreeControlsDisabled(), false, 'Tree controls should re-enable once the search is cleared');
     }
   });
 
@@ -701,6 +706,7 @@ function resetPaint(scope, partPath) {
   assert.strictEqual(state.filteringActive, false, 'Clearing identifier filter should restore tree view');
   assert.strictEqual(state.filterResults.length, 0, 'Clearing identifier filter should clear filtered list data');
   assert.strictEqual(state.filteredParts.length, scope.state.parts.length, 'Clearing identifier filter should restore all parts');
+  assert.strictEqual(scope.areTreeControlsDisabled(), false, 'Tree controls should enable after clearing identifier filter');
   const treeAfterIdentifierClear = JSON.stringify(state.filteredTree);
   assert.strictEqual(treeAfterIdentifierClear, initialTreeSnapshot, 'Tree should remain unchanged after identifier filtering');
 
@@ -718,6 +724,7 @@ function resetPaint(scope, partPath) {
   scope.clearFilter();
   scope.$digest();
   node = findNode(state.filteredTree, 'vehicle/root');
+  assert.strictEqual(scope.areTreeControlsDisabled(), false, 'Clearing filter helper should leave tree controls enabled');
   assert(node && scope.hasCustomBadge(node.part), 'Part 1 should retain custom paint after updating another part');
   node = findNode(state.filteredTree, 'vehicle/hood');
   assert(node && scope.hasCustomBadge(node.part), 'Part 2 should show custom paint after apply');

--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -501,6 +501,15 @@
       display: inline-flex;
       gap: 0;
     }
+    .vehicle-parts-painting .filtered-results .filtered-slot .filtered-slot-text {
+      display: inline-flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+    .vehicle-parts-painting .filtered-results .filtered-slot .filtered-slot-word {
+      display: inline-flex;
+      gap: 0;
+    }
     .vehicle-parts-painting .filtered-results .filtered-slot,
     .vehicle-parts-painting .filtered-results .filtered-identifier {
       display: flex;
@@ -1684,8 +1693,16 @@
             <div class="filtered-slot" ng-if="result.slotSegments.length">
               <span class="label">Slot:</span>
               <span class="value">
-                <span ng-repeat="segment in result.slotSegments track by $index"
-                      ng-class="{'filter-highlight': segment.match}">{{segment.text}}</span>
+                <span class="filtered-slot-text">
+                  <span class="filtered-slot-word"
+                        ng-repeat="word in result.slotWordSegments track by $index">
+                    <span ng-repeat="segment in word.segments track by $index"
+                          ng-class="{'filter-highlight': segment.match}">{{segment.text}}</span>
+                  </span>
+                  <span ng-if="!result.slotWordSegments.length"
+                        ng-repeat="segment in result.slotSegments track by $index"
+                        ng-class="{'filter-highlight': segment.match}">{{segment.text}}</span>
+                </span>
               </span>
             </div>
             <div class="filtered-identifier" ng-if="result.identifierSegments.length">

--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -490,6 +490,13 @@
       font-size: 13px;
       font-weight: 600;
     }
+    .vehicle-parts-painting .filtered-results .filtered-name-text {
+      display: inline-flex;
+      flex: 1 1 auto;
+      flex-wrap: wrap;
+      gap: 0;
+      min-width: 0;
+    }
     .vehicle-parts-painting .filtered-results .filtered-slot,
     .vehicle-parts-painting .filtered-results .filtered-identifier {
       display: flex;
@@ -1658,8 +1665,10 @@
                ng-mouseenter="onPartMouseEnter(result.part)"
                ng-mouseleave="onPartMouseLeave(result.part)">
             <div class="filtered-name">
-              <span ng-repeat="segment in result.nameSegments track by $index"
-                    ng-class="{'filter-highlight': segment.match}">{{segment.text}}</span>
+              <span class="filtered-name-text">
+                <span ng-repeat="segment in result.nameSegments track by $index"
+                      ng-class="{'filter-highlight': segment.match}">{{segment.text}}</span>
+              </span>
               <span class="custom-tag" ng-if="hasCustomBadge(result.part)">CUSTOM PAINT</span>
             </div>
             <div class="filtered-slot" ng-if="result.slotSegments.length">

--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -494,8 +494,12 @@
       display: inline-flex;
       flex: 1 1 auto;
       flex-wrap: wrap;
-      gap: 0;
+      gap: 6px;
       min-width: 0;
+    }
+    .vehicle-parts-painting .filtered-results .filtered-name-word {
+      display: inline-flex;
+      gap: 0;
     }
     .vehicle-parts-painting .filtered-results .filtered-slot,
     .vehicle-parts-painting .filtered-results .filtered-identifier {
@@ -1666,7 +1670,13 @@
                ng-mouseleave="onPartMouseLeave(result.part)">
             <div class="filtered-name">
               <span class="filtered-name-text">
-                <span ng-repeat="segment in result.nameSegments track by $index"
+                <span class="filtered-name-word"
+                      ng-repeat="word in result.nameWordSegments track by $index">
+                  <span ng-repeat="segment in word.segments track by $index"
+                        ng-class="{'filter-highlight': segment.match}">{{segment.text}}</span>
+                </span>
+                <span ng-if="!result.nameWordSegments.length"
+                      ng-repeat="segment in result.nameSegments track by $index"
                       ng-class="{'filter-highlight': segment.match}">{{segment.text}}</span>
               </span>
               <span class="custom-tag" ng-if="hasCustomBadge(result.part)">CUSTOM PAINT</span>

--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -458,6 +458,60 @@
       min-height: 0;
       overflow-y: auto;
     }
+    .vehicle-parts-painting .filtered-results {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+    }
+    .vehicle-parts-painting .filtered-results .filtered-part {
+      border-top: 1px solid rgba(255, 255, 255, 0.06);
+      padding: 8px 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      transition: background 0.15s ease;
+      cursor: pointer;
+    }
+    .vehicle-parts-painting .filtered-results .filtered-part:first-child {
+      border-top: none;
+    }
+    .vehicle-parts-painting .filtered-results .filtered-part:hover {
+      background: rgba(255, 255, 255, 0.08);
+    }
+    .vehicle-parts-painting .filtered-results .filtered-part.selected {
+      background: rgba(255, 255, 255, 0.18);
+    }
+    .vehicle-parts-painting .filtered-results .filtered-name {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+      font-weight: 600;
+    }
+    .vehicle-parts-painting .filtered-results .filtered-slot,
+    .vehicle-parts-painting .filtered-results .filtered-identifier {
+      display: flex;
+      align-items: baseline;
+      gap: 4px;
+      font-size: 11px;
+      opacity: 0.85;
+    }
+    .vehicle-parts-painting .filtered-results .filtered-slot .label,
+    .vehicle-parts-painting .filtered-results .filtered-identifier .label {
+      font-size: 10px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      opacity: 0.75;
+    }
+    .vehicle-parts-painting .filtered-results .filtered-slot .value,
+    .vehicle-parts-painting .filtered-results .filtered-identifier .value {
+      display: inline-flex;
+      flex-wrap: wrap;
+      gap: 0;
+    }
     .vehicle-parts-painting .parts-list .parts-tree,
     .vehicle-parts-painting .parts-list .parts-tree ul {
       list-style: none;
@@ -540,6 +594,10 @@
       text-transform: uppercase;
       letter-spacing: 0.05em;
       margin-top: 2px;
+    }
+    .vehicle-parts-painting .filter-highlight {
+      font-weight: 700;
+      color: #ff6600;
     }
     .vehicle-parts-painting .parts-list .empty,
     .vehicle-parts-painting .parts-list .no-results {
@@ -1587,12 +1645,40 @@
         </button>
       </div>
       <div class="parts-list">
-        <ul class="parts-tree" ng-if="state.filteredTree.length">
+        <ul class="parts-tree" ng-if="!state.filteringActive && state.filteredTree.length">
           <li class="tree-node"
               ng-repeat="node in state.filteredTree track by node.part.partPath"
               ng-include="'vehiclePartsPaintingTreeNode.html'"></li>
         </ul>
-        <div class="no-results" ng-if="state.parts.length && !state.filteredParts.length">No parts match your search.</div>
+        <div class="filtered-results" ng-if="state.filteringActive && state.filteredParts.length">
+          <div class="filtered-part"
+               ng-repeat="result in state.filterResults track by result.part.partPath"
+               ng-class="{selected: result.part.partPath === state.selectedPartPath}"
+               ng-click="selectPart(result.part)"
+               ng-mouseenter="onPartMouseEnter(result.part)"
+               ng-mouseleave="onPartMouseLeave(result.part)">
+            <div class="filtered-name">
+              <span ng-repeat="segment in result.nameSegments track by $index"
+                    ng-class="{'filter-highlight': segment.match}">{{segment.text}}</span>
+              <span class="custom-tag" ng-if="hasCustomBadge(result.part)">CUSTOM PAINT</span>
+            </div>
+            <div class="filtered-slot" ng-if="result.slotSegments.length">
+              <span class="label">Slot:</span>
+              <span class="value">
+                <span ng-repeat="segment in result.slotSegments track by $index"
+                      ng-class="{'filter-highlight': segment.match}">{{segment.text}}</span>
+              </span>
+            </div>
+            <div class="filtered-identifier" ng-if="result.identifierSegments.length">
+              <span class="label">Identifier:</span>
+              <span class="value">
+                <span ng-repeat="segment in result.identifierSegments track by $index"
+                      ng-class="{'filter-highlight': segment.match}">{{segment.text}}</span>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div class="no-results" ng-if="state.filteringActive && state.parts.length && !state.filteredParts.length">No parts match your search.</div>
         <div class="empty" ng-if="!state.parts.length">No paintable parts detected.</div>
       </div>
       <script type="text/ng-template" id="vehiclePartsPaintingTreeNode.html">

--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -421,6 +421,11 @@
       width: 90%;
       height: 90%;
     }
+    .vehicle-parts-painting .parts-panel .panel-header .panel-actions button:disabled {
+      background: transparent;
+      border: 1px solid rgba(255, 255, 255, 0.3);
+      color: rgba(255, 255, 255, 0.3);
+    }
     .vehicle-parts-painting .filter-field {
       padding: 8px 10px;
       border-bottom: 1px solid rgba(255, 255, 255, 0.08);
@@ -1616,7 +1621,7 @@
   </div>
   <div class="app-content" ng-if="!state.minimized">
     <div class="app-header">
-      <h2><img src="/ui/modules/apps/vehiclePartsPainting/icon_minimize.svg" alt="" style="width: 20px; height: 20px;">&nbsp;Vehicle Parts Painting <span style="font-style: italic; font-size: 10px; opacity: 0.5; margin-left: 2em;">version 1.1.1-dev | made by KRtekTM</span></h2>
+      <h2><img src="/ui/modules/apps/vehiclePartsPainting/icon_minimize.svg" alt="" style="width: 20px; height: 20px;">&nbsp;Vehicle Parts Painting <span style="font-style: italic; font-size: 10px; opacity: 0.5; margin-left: 2em;">version 1.1.1 | made by KRtekTM</span></h2>
       <div class="header-actions">
         <button type="button" ng-click="refresh()">
           <svg width="12px" height="12px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -1640,8 +1640,12 @@
       <div class="panel-header">
         <div style="margin-bottom: 6px;"><span>Vehicle Parts Selector</span></div>
         <div class="panel-actions">
-          <button type="button" ng-click="collapseAllNodes()">Collapse all</button>
-          <button type="button" ng-click="expandAllNodes()">Expand all</button>
+          <button type="button"
+                  ng-click="collapseAllNodes()"
+                  ng-disabled="areTreeControlsDisabled()">Collapse all</button>
+          <button type="button"
+                  ng-click="expandAllNodes()"
+                  ng-disabled="areTreeControlsDisabled()">Expand all</button>
           <button type="button" ng-click="showAllParts()" class="orange">
             <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
               <path d="M0 0h24v24H0z" fill="none"/>

--- a/ui/modules/apps/vehiclePartsPainting/app.js
+++ b/ui/modules/apps/vehiclePartsPainting/app.js
@@ -50,6 +50,8 @@ angular.module('beamng.apps')
         hasUserSelectedPart: false,
         filterText: '',
         filteredParts: [],
+        filteringActive: false,
+        filterResults: [],
         expandedNodes: {},
         minimized: false,
         minimizedAlignment: 'left',
@@ -1607,6 +1609,8 @@ end)()`;
         if (part.partName) { fields.push(part.partName); }
         if (part.slotName) { fields.push(part.slotName); }
         if (part.slotLabel) { fields.push(part.slotLabel); }
+        if (part.partPath) { fields.push(part.partPath); }
+        if (part.slotPath) { fields.push(part.slotPath); }
         for (let i = 0; i < fields.length; i++) {
           const value = fields[i];
           if (typeof value === 'string' && value.toLowerCase().indexOf(lowered) !== -1) {
@@ -1614,6 +1618,47 @@ end)()`;
           }
         }
         return false;
+      }
+
+      function buildHighlightSegments(value, loweredFilter, filterLength) {
+        const text = (value === undefined || value === null) ? '' : String(value);
+        if (!text) { return []; }
+        if (!loweredFilter || !filterLength) {
+          return [{ text: text, match: false }];
+        }
+        const loweredText = text.toLowerCase();
+        const segments = [];
+        let searchIndex = 0;
+        let matchIndex = loweredText.indexOf(loweredFilter, searchIndex);
+        while (matchIndex !== -1) {
+          if (matchIndex > searchIndex) {
+            segments.push({ text: text.substring(searchIndex, matchIndex), match: false });
+          }
+          const endIndex = matchIndex + filterLength;
+          segments.push({ text: text.substring(matchIndex, endIndex), match: true });
+          searchIndex = endIndex;
+          matchIndex = loweredText.indexOf(loweredFilter, searchIndex);
+        }
+        if (searchIndex < text.length) {
+          segments.push({ text: text.substring(searchIndex), match: false });
+        }
+        if (!segments.length) {
+          segments.push({ text: text, match: false });
+        }
+        return segments;
+      }
+
+      function createFilterResult(part, loweredFilter) {
+        const filterLength = loweredFilter ? loweredFilter.length : 0;
+        const displayName = part && (part.displayName || part.partName || part.partPath || '');
+        const slotLabel = part && (part.slotLabel || part.slotName || '');
+        const identifier = part && (part.partPath || part.partName || '');
+        return {
+          part: part,
+          nameSegments: buildHighlightSegments(displayName, loweredFilter, filterLength),
+          slotSegments: buildHighlightSegments(slotLabel, loweredFilter, filterLength),
+          identifierSegments: buildHighlightSegments(identifier, loweredFilter, filterLength)
+        };
       }
 
       function normalizeSlotPath(slotPath) {
@@ -1651,20 +1696,6 @@ end)()`;
         const pathA = a.part && a.part.partPath ? String(a.part.partPath) : '';
         const pathB = b.part && b.part.partPath ? String(b.part.partPath) : '';
         return pathA < pathB ? -1 : (pathA > pathB ? 1 : 0);
-      }
-
-      function cloneTreeNodes(nodes) {
-        if (!Array.isArray(nodes)) { return []; }
-        const result = [];
-        for (let i = 0; i < nodes.length; i++) {
-          const node = nodes[i];
-          if (!node || !node.part) { continue; }
-          result.push({
-            part: node.part,
-            children: cloneTreeNodes(Array.isArray(node.children) ? node.children : [])
-          });
-        }
-        return result;
       }
 
       function buildPartsTree(parts) {
@@ -1732,43 +1763,6 @@ end)()`;
         return roots;
       }
 
-      function filterTreeNodes(nodes, filter) {
-        if (!Array.isArray(nodes)) { return []; }
-        const result = [];
-        for (let i = 0; i < nodes.length; i++) {
-          const node = nodes[i];
-          if (!node || !node.part) { continue; }
-          const matchesSelf = matchesFilter(node.part, filter);
-          let children = [];
-          if (matchesSelf) {
-            children = cloneTreeNodes(Array.isArray(node.children) ? node.children : []);
-          } else {
-            children = filterTreeNodes(Array.isArray(node.children) ? node.children : [], filter);
-          }
-          if (matchesSelf || children.length) {
-            result.push({
-              part: node.part,
-              children: children
-            });
-          }
-        }
-        return result;
-      }
-
-      function expandFilteredNodes(nodes) {
-        if (!Array.isArray(nodes)) { return; }
-        for (let i = 0; i < nodes.length; i++) {
-          const node = nodes[i];
-          if (!node || !node.part) { continue; }
-          if (node.part.partPath) {
-            state.expandedNodes[node.part.partPath] = true;
-          }
-          if (node.children && node.children.length) {
-            expandFilteredNodes(node.children);
-          }
-        }
-      }
-
       function setExpansionForNodes(nodes, expanded) {
         if (!Array.isArray(nodes)) { return; }
         for (let i = 0; i < nodes.length; i++) {
@@ -1784,7 +1778,8 @@ end)()`;
       function computeFilteredParts() {
         ensurePartsTreeCurrent();
         const rawFilter = typeof state.filterText === 'string' ? state.filterText : '';
-        const normalized = rawFilter.trim().toLowerCase();
+        const trimmedFilter = rawFilter.trim();
+        const normalized = trimmedFilter.toLowerCase();
         const parts = Array.isArray(state.parts) ? state.parts.slice() : [];
         let filtered = parts;
         if (normalized) {
@@ -1793,14 +1788,15 @@ end)()`;
           });
         }
         state.filteredParts = filtered;
-
-        if (!normalized) {
-          state.filteredTree = state.partsTree;
+        state.filteringActive = !!normalized;
+        if (state.filteringActive) {
+          state.filterResults = filtered.map(function (part) {
+            return createFilterResult(part, normalized);
+          });
         } else {
-          const tree = filterTreeNodes(state.partsTree, normalized);
-          state.filteredTree = tree;
-          expandFilteredNodes(tree);
+          state.filterResults = [];
         }
+        state.filteredTree = state.partsTree;
 
         const hoveredPath = state.hoveredPartPath;
         if (hoveredPath && !filtered.some(function (part) { return part.partPath === hoveredPath; })) {
@@ -2505,6 +2501,8 @@ end)()`;
             resetTreeNodeLookup();
             state.filteredTree = [];
             state.filteredParts = [];
+            state.filterResults = [];
+            state.filteringActive = false;
             state.expandedNodes = {};
             state.savedConfigs = [];
             state.selectedSavedConfig = null;
@@ -2529,6 +2527,8 @@ end)()`;
             clearPendingReplacement();
             clearCustomPaintState();
             state.filterText = '';
+            state.filterResults = [];
+            state.filteringActive = false;
             state.expandedNodes = {};
             state.savedConfigs = [];
             state.selectedSavedConfig = null;

--- a/ui/modules/apps/vehiclePartsPainting/app.js
+++ b/ui/modules/apps/vehiclePartsPainting/app.js
@@ -2244,6 +2244,10 @@ end)()`;
         setExpansionForNodes(state.partsTree, false);
       };
 
+      $scope.areTreeControlsDisabled = function () {
+        return !!state.filteringActive;
+      };
+
       $scope.clearFilter = function () {
         state.filterText = '';
       };

--- a/ui/modules/apps/vehiclePartsPainting/app.js
+++ b/ui/modules/apps/vehiclePartsPainting/app.js
@@ -1711,12 +1711,15 @@ end)()`;
         const slotLabel = part && (part.slotLabel || part.slotName || '');
         const identifier = part && (part.partPath || part.partName || '');
         const nameSegments = buildHighlightSegments(displayName, loweredFilter, filterLength);
+        const slotSegments = buildHighlightSegments(slotLabel, loweredFilter, filterLength);
+        const identifierSegments = buildHighlightSegments(identifier, loweredFilter, filterLength);
         return {
           part: part,
           nameSegments: nameSegments,
           nameWordSegments: groupSegmentsIntoWords(nameSegments),
-          slotSegments: buildHighlightSegments(slotLabel, loweredFilter, filterLength),
-          identifierSegments: buildHighlightSegments(identifier, loweredFilter, filterLength)
+          slotSegments: slotSegments,
+          slotWordSegments: groupSegmentsIntoWords(slotSegments),
+          identifierSegments: identifierSegments
         };
       }
 


### PR DESCRIPTION
## Summary
- render a flat filtered parts list whenever the search box is used while leaving the tree untouched
- highlight matching substrings across part names, slots, and identifiers in the filtered list
- extend the controller tests with scenarios that exercise the new filtering workflow and validations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc7a44822c8329b5e6f3b2bfd1d6ae