### PR TITLE
Redirect vehicle parts painting menu to UI app selector

### DIFF
--- a/lua/ge/extensions/ui_topBar_vehiclePartsPainting.lua
+++ b/lua/ge/extensions/ui_topBar_vehiclePartsPainting.lua
@@ -14,7 +14,7 @@ local desiredItemDefinition = {
   label = 'vehiclePartsPainting.topbarLabel',
   icon = 'engine',
   targetState = 'menu.vehiclePartsPainting',
-  substate = 'menu.vehiclePartsPainting',
+  substate = 'menu.appselect',
   order = 250,
   flags = {'inGameOnly', 'noMission', 'noScenario', 'noGarage'},
 }

--- a/ui/modules/menu/menu-vehiclePartsPainting.js
+++ b/ui/modules/menu/menu-vehiclePartsPainting.js
@@ -43,17 +43,78 @@
         backState: 'BACK_TO_MENU',
         onEnter: ['$injector', '$window', function ($injector, $window) {
           var api = resolveBngApi($injector, $window)
-          if (!api) { return }
-          runLua(api, 'extensions.load("ui_topBar_vehiclePartsPainting")')
-          runLua(api, 'extensions.load("freeroam_vehiclePartsPainting")')
-          runLua(api, 'freeroam_vehiclePartsPainting.open()')
-          runLua(api, 'ui_topBar.setActiveItem("vehiclePartsPainting")')
+          var consoleRef = ($window && $window.console) || (typeof console !== 'undefined' ? console : null)
+          var logWarn = function (message, err) {
+            if (!consoleRef || typeof consoleRef.warn !== 'function') { return }
+            if (err) {
+              consoleRef.warn(message, err)
+              return
+            }
+            consoleRef.warn(message)
+          }
+
+          if (api) {
+            runLua(api, 'extensions.load("ui_topBar_vehiclePartsPainting")')
+            runLua(api, 'extensions.load("freeroam_vehiclePartsPainting")')
+            runLua(api, 'ui_topBar.setActiveItem("vehiclePartsPainting")')
+          }
+
+          if (!$injector || typeof $injector.get !== 'function') {
+            logWarn('VehiclePartsPainting menu: Angular injector unavailable; cannot open UI Apps selector.')
+            return
+          }
+
+          var resolveDependency = function (token) {
+            if (typeof $injector.has === 'function') {
+              try {
+                if (!$injector.has(token)) {
+                  logWarn('VehiclePartsPainting menu: dependency "' + token + '" not available.')
+                  return null
+                }
+              } catch (err) {
+                logWarn('VehiclePartsPainting menu: unable to check dependency "' + token + '".', err)
+              }
+            }
+
+            try {
+              return $injector.get(token)
+            } catch (err) {
+              logWarn('VehiclePartsPainting menu: failed to resolve dependency "' + token + '".', err)
+              return null
+            }
+          }
+
+          var stateService = resolveDependency('$state')
+          var timeoutService = resolveDependency('$timeout')
+          var filtersService = resolveDependency('AppSelectFilters')
+
+          if (filtersService && typeof filtersService === 'object') {
+            filtersService.query = 'Vehicle Parts Painting'
+          } else if (!filtersService) {
+            // already warned during resolution
+          } else {
+            logWarn('VehiclePartsPainting menu: AppSelectFilters service did not provide an object to update.')
+          }
+
+          if (!timeoutService || typeof timeoutService !== 'function') {
+            logWarn('VehiclePartsPainting menu: $timeout service unavailable; cannot navigate to UI Apps selector.')
+            return
+          }
+
+          if (!stateService || typeof stateService.go !== 'function') {
+            logWarn('VehiclePartsPainting menu: $state service unavailable; cannot navigate to UI Apps selector.')
+            return
+          }
+
+          timeoutService(function () {
+            try {
+              stateService.go('menu.appselect', {}, { inherit: false, location: 'replace' })
+            } catch (err) {
+              logWarn('VehiclePartsPainting menu: failed to navigate to UI Apps selector.', err)
+            }
+          }, 0)
         }],
-        onExit: ['$injector', '$window', function ($injector, $window) {
-          var api = resolveBngApi($injector, $window)
-          if (!api) { return }
-          runLua(api, 'freeroam_vehiclePartsPainting.close()')
-        }]
+        onExit: angular.noop
       })
     }])
 })()


### PR DESCRIPTION
## Summary
- navigate from the vehicle parts painting menu to the UI app selector when the state loads
- ensure the top bar entry stays active while working in the UI app selector

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cca5684a208329a089516745f68623