### PR TITLE
Capture screenshot before saving configuration

### DIFF
--- a/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
+++ b/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
@@ -1108,6 +1108,29 @@ local function saveCurrentUserConfig(configName)
           fileName = fileName .. '.pc'
         end
 
+        local screenshotExtensionName = 'util_screenshotCreator'
+        local screenshotLabel = tostring(displayName or sanitizedBaseName)
+        if not extensions or type(extensions.load) ~= 'function' then
+          log('W', logTag, string.format('Unable to capture configuration thumbnail for "%s": extensions.load unavailable', screenshotLabel))
+        else
+          local okLoad, loadErr = safePcall(function()
+            return extensions.load(screenshotExtensionName)
+          end)
+          if not okLoad then
+            log('W', logTag, string.format('Unable to load %s extension for "%s": %s', screenshotExtensionName, screenshotLabel, tostring(loadErr)))
+          end
+
+          local screenshotExtension = getLoadedExtension(screenshotExtensionName)
+          if screenshotExtension and type(screenshotExtension.startWork) == 'function' then
+            local okStart, startErr = safePcall(screenshotExtension.startWork, { selection = sanitizedBaseName })
+            if not okStart then
+              log('W', logTag, string.format('Failed to start %s for "%s": %s', screenshotExtensionName, screenshotLabel, tostring(startErr)))
+            end
+          else
+            log('W', logTag, string.format('Unable to capture configuration thumbnail for "%s": %s extension unavailable or missing startWork', screenshotLabel, screenshotExtensionName))
+          end
+        end
+
         local okSave, resultOrErr = safePcall(saveEntryPoint, fileName)
         if okSave and resultOrErr ~= false then
           if displayName and displayName ~= '' then
@@ -1118,28 +1141,6 @@ local function saveCurrentUserConfig(configName)
             end
           else
             log('I', logTag, string.format('Saved vehicle configuration "%s" via core_vehicle_partmgmt.%s', tostring(fileName), tostring(saveEntryPointName)))
-          end
-
-          local screenshotExtensionName = 'util_screenshotCreator'
-          if not extensions or type(extensions.load) ~= 'function' then
-            log('W', logTag, string.format('Unable to capture configuration thumbnail for "%s": extensions.load unavailable', tostring(displayName or sanitizedBaseName)))
-          else
-            local okLoad, loadErr = safePcall(function()
-              return extensions.load(screenshotExtensionName)
-            end)
-            if not okLoad then
-              log('W', logTag, string.format('Unable to load %s extension for "%s": %s', screenshotExtensionName, tostring(displayName or sanitizedBaseName), tostring(loadErr)))
-            end
-
-            local screenshotExtension = getLoadedExtension(screenshotExtensionName)
-            if screenshotExtension and type(screenshotExtension.startWork) == 'function' then
-              local okStart, startErr = safePcall(screenshotExtension.startWork, { selection = sanitizedBaseName })
-              if not okStart then
-                log('W', logTag, string.format('Failed to start %s for "%s": %s', screenshotExtensionName, tostring(displayName or sanitizedBaseName), tostring(startErr)))
-              end
-            else
-              log('W', logTag, string.format('Unable to capture configuration thumbnail for "%s": %s extension unavailable or missing startWork', tostring(displayName or sanitizedBaseName), screenshotExtensionName))
-            end
           end
         else
           local errorMessage


### PR DESCRIPTION
## Summary
- start the configuration thumbnail capture before invoking the save entry point so the screenshot is taken first
- keep the existing logging for successful and failed saves

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cccf9c65408329bb14aa00d46cc8e5