### PR TITLE
Show replace dialog preview and refresh saved config screenshots

### DIFF
--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -1522,6 +1522,20 @@
       <p class="file-hint" ng-if="state.pendingSanitizedName">
         File name: {{state.pendingSanitizedName}}.pc
       </p>
+      <div class="config-target"
+           ng-if="state.pendingExistingConfig">
+        <div class="config-target-preview">
+          <img ng-src="{{getSavedConfigPreviewSrc(state.pendingExistingConfig)}}"
+               ng-attr-alt="{{getSavedConfigLabel(state.pendingExistingConfig)}} preview">
+        </div>
+        <div class="config-target-details">
+          <div class="config-target-name">{{getSavedConfigLabel(state.pendingExistingConfig)}}</div>
+          <div class="config-target-meta"
+               ng-if="state.pendingExistingConfig.relativePath">
+            File: {{state.pendingExistingConfig.relativePath}}
+          </div>
+        </div>
+      </div>
       <div class="dialog-actions">
         <button type="button" class="confirm" ng-click="confirmReplaceSavedConfig()">Replace</button>
         <button type="button" class="cancel" ng-click="cancelReplaceSavedConfig()">Cancel</button>


### PR DESCRIPTION
## Summary
- show the target configuration preview inside the replace confirmation dialog
- refresh saved configuration preview URLs when a replacement occurs and poll until new screenshots are available
- reuse preview refresh tracking during replacement saves to keep images up to date

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd63ed8b5883299ac8c52b7e487844