### PR TITLE
Defer motion warning dialog while minimized

### DIFF
--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -1497,7 +1497,7 @@
     }
   </style>
   <div class="motion-warning-overlay"
-       ng-if="state.motionWarning.dialogVisible"
+       ng-if="state.motionWarning.dialogVisible && !state.minimized"
        role="dialog"
        aria-modal="true"
        aria-labelledby="motion-warning-title"

--- a/ui/modules/apps/vehiclePartsPainting/app.js
+++ b/ui/modules/apps/vehiclePartsPainting/app.js
@@ -92,7 +92,8 @@ angular.module('beamng.apps')
           acknowledged: false,
           dialogVisible: false,
           speed: 0,
-          vehicleId: null
+          vehicleId: null,
+          pending: false
         }
       };
 
@@ -2392,17 +2393,29 @@ end)()`;
         state.minimizedAlignment = presentation.alignment;
         state.minimizedInlineStyle = presentation.style;
         state.minimized = true;
+
+        if (state.motionWarning.dialogVisible && !state.motionWarning.acknowledged) {
+          state.motionWarning.dialogVisible = false;
+          state.motionWarning.pending = true;
+        }
       };
 
       $scope.restoreApp = function () {
         state.minimized = false;
         state.minimizedAlignment = 'left';
         state.minimizedInlineStyle = {};
+
+        if (state.motionWarning.pending && state.motionWarning.moving && !state.motionWarning.acknowledged) {
+          state.motionWarning.dialogVisible = true;
+        }
+
+        state.motionWarning.pending = false;
       };
 
       $scope.dismissMotionWarning = function () {
         state.motionWarning.dialogVisible = false;
         state.motionWarning.acknowledged = true;
+        state.motionWarning.pending = false;
       };
 
       $scope.confirmLiveryEditorLaunch = function () {
@@ -2912,6 +2925,7 @@ end)()`;
             state.motionWarning.moving = false;
             state.motionWarning.dialogVisible = false;
             state.motionWarning.acknowledged = false;
+            state.motionWarning.pending = false;
             state.motionWarning.speed = 0;
             state.motionWarning.vehicleId = null;
             return;
@@ -2944,6 +2958,7 @@ end)()`;
             state.motionWarning.moving = false;
             state.motionWarning.dialogVisible = false;
             state.motionWarning.acknowledged = false;
+            state.motionWarning.pending = false;
             state.motionWarning.speed = 0;
             state.motionWarning.vehicleId = state.vehicleId;
           }
@@ -2987,6 +3002,7 @@ end)()`;
             state.motionWarning.moving = false;
             state.motionWarning.dialogVisible = false;
             state.motionWarning.acknowledged = false;
+            state.motionWarning.pending = false;
             state.motionWarning.speed = 0;
             state.motionWarning.vehicleId = reportedVehicleId;
             return;
@@ -3000,6 +3016,7 @@ end)()`;
           if (vehicleChanged) {
             state.motionWarning.vehicleId = reportedVehicleId;
             state.motionWarning.acknowledged = false;
+            state.motionWarning.pending = false;
           }
 
           const moving = !!data.moving && reportedVehicleId !== null;
@@ -3009,8 +3026,17 @@ end)()`;
           if (!moving) {
             state.motionWarning.dialogVisible = false;
             state.motionWarning.acknowledged = false;
+            state.motionWarning.pending = false;
           } else if (!state.motionWarning.acknowledged) {
-            state.motionWarning.dialogVisible = true;
+            if (state.minimized) {
+              state.motionWarning.dialogVisible = false;
+              state.motionWarning.pending = true;
+            } else {
+              state.motionWarning.dialogVisible = true;
+              state.motionWarning.pending = false;
+            }
+          } else {
+            state.motionWarning.pending = false;
           }
         });
       });


### PR DESCRIPTION
## Summary
- add a pending state for the motion warning so the dialog is suppressed while the app is minimized
- restore the motion warning dialog after unminimizing if the vehicle is still moving and the warning has not been acknowledged
- guard the motion warning overlay so it is never rendered while the widget is minimized

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdeba7bf2083299a3442bb72d04e59