### PR TITLE
Prevent extension commands before freeroam module loads

### DIFF
--- a/.tests/vehiclePartsPainting.test.js
+++ b/.tests/vehiclePartsPainting.test.js
@@ -791,7 +791,8 @@ function resetPaint(scope, partPath) {
   scope.$digest();
   assert(!scope.hasBasePaintChanges(), 'Base paint change state should clear after apply');
   const lastCommand = bngApiCalls[bngApiCalls.length - 1];
-  assert(lastCommand && lastCommand.startsWith('freeroam_vehiclePartsPainting.setVehicleBasePaintsJson('), 'Base paint command should be queued');
+  assert(lastCommand && lastCommand.startsWith('if freeroam_vehiclePartsPainting then '), 'Base paint command should guard extension availability');
+  assert(lastCommand && lastCommand.includes('freeroam_vehiclePartsPainting.setVehicleBasePaintsJson('), 'Base paint command should be queued');
   const updatedBasePaint = scope.state.basePaints[0];
   assert(Math.abs(updatedBasePaint.baseColor[1] - (128 / 255)) < 0.001, 'Base paint green channel should update');
   assert(Math.abs(updatedBasePaint.baseColor[2] - (64 / 255)) < 0.001, 'Base paint blue channel should update');
@@ -935,7 +936,8 @@ function resetPaint(scope, partPath) {
   assert(state.deleteConfigDialog.isDeleting, 'Delete dialog should mark deletion in progress');
   assert.strictEqual(bngApiCalls.length, deleteCommandCountBefore + 1, 'Confirming delete should queue a backend command');
   const deleteCommand = bngApiCalls[bngApiCalls.length - 1];
-  assert.strictEqual(deleteCommand, "freeroam_vehiclePartsPainting.deleteSavedConfiguration('vehicles/example/config_a.pc')", 'Delete command should include sanitized path');
+  assert(deleteCommand && deleteCommand.startsWith('if freeroam_vehiclePartsPainting then '), 'Delete command should guard extension availability');
+  assert(deleteCommand && deleteCommand.includes("freeroam_vehiclePartsPainting.deleteSavedConfiguration('vehicles/example/config_a.pc')"), 'Delete command should include sanitized path');
 
   scope.$$emit('VehiclePartsPaintingSavedConfigs', {
     vehicleId: 4242,

--- a/ui/modules/apps/vehiclePartsPainting/app.js
+++ b/ui/modules/apps/vehiclePartsPainting/app.js
@@ -779,6 +779,11 @@ angular.module('beamng.apps')
         return "'" + String(str).replace(/\\/g, '\\\\').replace(/'/g, "\\'") + "'";
       }
 
+      function sendExtensionCommand(command) {
+        if (typeof command !== 'string' || !command) { return; }
+        bngApi.engineLua('if freeroam_vehiclePartsPainting then ' + command + ' end');
+      }
+
       function sendUiMessage(messageText) {
         if (messageText === undefined || messageText === null) { return; }
         const text = String(messageText);
@@ -1191,7 +1196,7 @@ end)()`;
         }
         scheduleSavedConfigRefresh(SAVED_CONFIG_FAST_REFRESH_INTERVAL_MS);
         const command = 'freeroam_vehiclePartsPainting.saveCurrentConfiguration(' + toLuaString(name) + ')';
-        bngApi.engineLua(command);
+        sendExtensionCommand(command);
       }
 
       function createViewPaint(paint) {
@@ -1624,7 +1629,7 @@ end)()`;
         applyBasePaintsLocally(paints);
         const payload = { paints: paints };
         const command = 'freeroam_vehiclePartsPainting.setVehicleBasePaintsJson(' + toLuaString(JSON.stringify(payload)) + ')';
-        bngApi.engineLua(command);
+        sendExtensionCommand(command);
       };
 
       $scope.resetBasePaintEditors = function () {
@@ -1656,11 +1661,11 @@ end)()`;
       }
 
       function sendShowAllCommand() {
-        bngApi.engineLua('freeroam_vehiclePartsPainting.showAllParts()');
+        sendExtensionCommand('freeroam_vehiclePartsPainting.showAllParts()');
       }
 
       function requestSavedConfigs() {
-        bngApi.engineLua('freeroam_vehiclePartsPainting.requestSavedConfigs()');
+        sendExtensionCommand('freeroam_vehiclePartsPainting.requestSavedConfigs()');
       }
 
       function cancelSavedConfigRefreshTimer() {
@@ -1765,7 +1770,7 @@ end)()`;
       function highlightPart(partPath) {
         if (!partPath) { return; }
         const command = 'freeroam_vehiclePartsPainting.highlightPart(' + toLuaString(partPath) + ')';
-        bngApi.engineLua(command);
+        sendExtensionCommand(command);
       }
 
       function beginPartHover(part) {
@@ -2697,7 +2702,7 @@ end)()`;
       };
 
       $scope.refresh = function () {
-        bngApi.engineLua('freeroam_vehiclePartsPainting.requestState()');
+        sendExtensionCommand('freeroam_vehiclePartsPainting.requestState()');
       };
 
       $scope.refreshSavedConfigs = function () {
@@ -2906,7 +2911,7 @@ end)()`;
         resetSavedConfigPreviewTracking();
         scheduleSavedConfigRefresh(SAVED_CONFIG_FAST_REFRESH_INTERVAL_MS);
         const command = 'freeroam_vehiclePartsPainting.deleteSavedConfiguration(' + toLuaString(target.relativePath) + ')';
-        bngApi.engineLua(command);
+        sendExtensionCommand(command);
       };
 
       $scope.saveCurrentConfiguration = function () {
@@ -2953,7 +2958,7 @@ end)()`;
         if (!target || !target.relativePath) { return; }
         state.isSpawningConfig = true;
         const command = 'freeroam_vehiclePartsPainting.spawnSavedConfiguration(' + toLuaString(target.relativePath) + ')';
-        bngApi.engineLua(command);
+        sendExtensionCommand(command);
       };
 
       $scope.applyPaint = function () {
@@ -2972,7 +2977,7 @@ end)()`;
           paints: paints
         };
         const command = 'freeroam_vehiclePartsPainting.applyPartPaintJson(' + toLuaString(JSON.stringify(payload)) + ')';
-        bngApi.engineLua(command);
+        sendExtensionCommand(command);
       };
 
       $scope.resetPaint = function () {
@@ -2993,7 +2998,7 @@ end)()`;
           }
         }
         computeFilteredParts();
-        bngApi.engineLua('freeroam_vehiclePartsPainting.resetPartPaint(' + toLuaString(partPath) + ')');
+        sendExtensionCommand('freeroam_vehiclePartsPainting.resetPartPaint(' + toLuaString(partPath) + ')');
       };
 
       $scope.showAllParts = function () {


### PR DESCRIPTION
## Summary
- add a helper that wraps freeroam vehicle parts painting engineLua commands with an extension availability guard
- update UI code to use the guarded helper for all freeroam commands and refresh associated unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cff6a75a388329be94154be38cc6cc