### PR TITLE
Add console restore command for Vehicle Parts Painting app

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ Notice: Custom paint can be applied to any vehicle part, but **the color will on
 6. Click **Apply paint to part** to push the changes to the vehicle. Use **Reset to vehicle paints** to revert to the current vehicle-wide paint scheme.
 
 The mod adds a game-side Lua extension (`lua/ge/extensions/freeroam/vehiclePartsPainting.lua`) that bridges the UI app and the vehicle simulation, ensuring paints are validated and synchronized with the vehicle state.
+
+## Troubleshooting
+
+- **Restore the app when the button is missing** – Open the BeamNG console (`~`) and run `freeroam_vehiclePartsPainting.restoreApp()` to bring the Vehicle Parts Painting widget back to its full size. This mirrors the in-app restore button, clearing the minimized state and returning the window to its default position.

--- a/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
+++ b/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
@@ -3807,6 +3807,10 @@ local function clearHighlight(targetVehId)
   showAllParts(targetVehId)
 end
 
+local function restoreApp()
+  guihooks.trigger('VehiclePartsPaintingRestoreApp', { source = 'extension' })
+end
+
 local function requestState()
   sendState()
 end
@@ -4059,6 +4063,7 @@ M.setVehicleBasePaintsJson = setVehicleBasePaintsJson
 M.highlightPart = highlightPart
 M.showAllParts = showAllParts
 M.clearHighlight = clearHighlight
+M.restoreApp = restoreApp
 M.onVehiclePartsPaintingResult = onVehiclePartsPaintingResult
 M.saveCurrentConfiguration = saveCurrentConfiguration
 M.deleteSavedConfiguration = deleteSavedConfiguration

--- a/ui/modules/apps/vehiclePartsPainting/app.js
+++ b/ui/modules/apps/vehiclePartsPainting/app.js
@@ -3314,6 +3314,13 @@ end)()`;
         sendShowAllCommand();
       });
 
+      $scope.$on('VehiclePartsPaintingRestoreApp', function () {
+        markExtensionAvailable();
+        $scope.$evalAsync(function () {
+          $scope.restoreApp();
+        });
+      });
+
       $scope.$on('VehiclePartsPaintingState', function (event, data) {
         markExtensionAvailable();
         data = data || {};


### PR DESCRIPTION
## Summary
- expose a VehiclePartsPaintingRestoreApp event handler in the UI so the restore logic can be triggered externally
- add a freeroam_vehiclePartsPainting.restoreApp console command that fires the new event to unminimize the widget
- document the console command in the README for easy discovery

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8796e78f483299e0525b437a9b364