### PR TITLE
Add randomize colors panel for vehicle parts

### DIFF
--- a/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
+++ b/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
@@ -3595,6 +3595,38 @@ local function onVehiclePartsPaintingResult(vehId, partPath, partName, slotPath,
       end
     end
   end
+
+  local finalPartPath = resolvedPartPath or partPath
+  local finalPartName = partName
+  local finalSlotPath = slotPath
+
+  if stateEntry then
+    if stateEntry.partName and stateEntry.partName ~= '' then
+      finalPartName = stateEntry.partName
+    end
+    if stateEntry.slotPath and stateEntry.slotPath ~= '' then
+      finalSlotPath = stateEntry.slotPath
+    end
+  end
+
+  if descriptorEntry then
+    if descriptorEntry.partName and descriptorEntry.partName ~= '' then
+      finalPartName = descriptorEntry.partName
+    end
+    if descriptorEntry.slotPath and descriptorEntry.slotPath ~= '' then
+      finalSlotPath = descriptorEntry.slotPath
+    end
+  end
+
+  guihooks.trigger('VehiclePartsPaintingApplyResult', {
+    vehicleId = vehId,
+    partPath = finalPartPath,
+    partName = finalPartName,
+    slotPath = finalSlotPath,
+    success = wasSuccessful,
+    identifier = identifier,
+    errorMessage = errorMessage
+  })
 end
 
 local function resolveHighlightInfo(vehId, partPath)

--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -34,6 +34,7 @@
     }
     .vehicle-parts-painting .config-confirm-overlay,
     .vehicle-parts-painting .palette-dialog-overlay,
+    .vehicle-parts-painting .randomizer-progress-overlay,
     .vehicle-parts-painting .color-picker-overlay {
       position: absolute;
       inset: 0;
@@ -49,7 +50,8 @@
       z-index: 5;
     }
     .vehicle-parts-painting .config-confirm-overlay,
-    .vehicle-parts-painting .palette-dialog-overlay {
+    .vehicle-parts-painting .palette-dialog-overlay,
+    .vehicle-parts-painting .randomizer-progress-overlay {
       z-index: 10;
     }
     .vehicle-parts-painting .config-confirm-dialog,
@@ -207,6 +209,81 @@
     }
     .vehicle-parts-painting .palette-dialog .dialog-actions .danger:hover {
       background: rgba(234, 80, 71, 1);
+    }
+    .vehicle-parts-painting .randomizer-progress-overlay {
+      align-items: center;
+      justify-content: center;
+      padding: 32px 16px;
+      z-index: 12;
+    }
+    .vehicle-parts-painting .randomizer-progress-dialog {
+      background: rgba(18, 18, 18, 0.94);
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      border-radius: 6px;
+      padding: 22px 24px;
+      max-width: 420px;
+      width: min(420px, 100%);
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      box-shadow: 0 10px 28px rgba(0, 0, 0, 0.55);
+      box-sizing: border-box;
+    }
+    .vehicle-parts-painting .randomizer-progress-dialog h3 {
+      margin: 0;
+      font-size: 18px;
+      font-weight: 600;
+    }
+    .vehicle-parts-painting .randomizer-progress-dialog p {
+      margin: 0;
+      font-size: 13px;
+      line-height: 1.5;
+    }
+    .vehicle-parts-painting .randomizer-progress-dialog .current-part-path {
+      font-size: 12px;
+      color: rgba(255, 255, 255, 0.7);
+    }
+    .vehicle-parts-painting .randomizer-progress-bar {
+      height: 8px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.12);
+      overflow: hidden;
+    }
+    .vehicle-parts-painting .randomizer-progress-bar .fill {
+      height: 100%;
+      background: rgba(0, 180, 255, 0.85);
+      transition: width 0.2s ease;
+    }
+    .vehicle-parts-painting .randomizer-progress-status {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-size: 13px;
+      color: rgba(255, 255, 255, 0.85);
+    }
+    .vehicle-parts-painting .randomizer-progress-status .spinner {
+      width: 18px;
+      height: 18px;
+    }
+    .vehicle-parts-painting .randomizer-progress-dialog .dialog-actions {
+      display: flex;
+      justify-content: flex-end;
+    }
+    .vehicle-parts-painting .randomizer-progress-dialog .dialog-actions .cancel {
+      min-width: 168px;
+      padding: 8px 16px;
+      border-radius: 4px;
+      font-weight: 600;
+      border: none;
+      background: rgba(255, 255, 255, 0.15);
+      color: #fff;
+    }
+    .vehicle-parts-painting .randomizer-progress-dialog .dialog-actions .cancel:hover {
+      background: rgba(255, 255, 255, 0.22);
+    }
+    .vehicle-parts-painting .randomizer-progress-dialog .dialog-actions .cancel:disabled {
+      opacity: 0.6;
+      cursor: default;
     }
     .vehicle-parts-painting .motion-warning-overlay {
       position: absolute;
@@ -1567,6 +1644,49 @@
       </div>
     </div>
   </div>
+  <div class="randomizer-progress-overlay"
+       ng-if="state.randomizerProgress.visible && !state.minimized"
+       role="dialog"
+       aria-modal="true"
+       aria-labelledby="randomizer-progress-title"
+       aria-describedby="randomizer-progress-description">
+    <div class="randomizer-progress-dialog">
+      <h3 id="randomizer-progress-title">Randomizing colors</h3>
+      <p id="randomizer-progress-description">
+        <span ng-if="state.randomizerProgress.total">
+          Painting part {{state.randomizerProgress.currentIndex + 1}} of {{state.randomizerProgress.total}}
+          <span ng-if="state.randomizerProgress.currentPartLabel">— {{state.randomizerProgress.currentPartLabel}}</span>
+        </span>
+        <span ng-if="!state.randomizerProgress.total">Preparing vibrant paints…</span>
+      </p>
+      <p class="current-part-path" ng-if="state.randomizerProgress.currentPartPath">
+        Identifier: {{state.randomizerProgress.currentPartPath}}
+      </p>
+      <div class="randomizer-progress-bar"
+           ng-if="state.randomizerProgress.total"
+           role="progressbar"
+           aria-valuemin="0"
+           ng-attr-aria-valuemax="{{state.randomizerProgress.total}}"
+           ng-attr-aria-valuenow="{{state.randomizerProgress.processedCount}}">
+        <div class="fill"
+             ng-style="{'width': getRandomizerProgressWidth()}"
+             aria-hidden="true"></div>
+      </div>
+      <div class="randomizer-progress-status" aria-live="polite">
+        <span class="spinner" aria-hidden="true"></span>
+        <span ng-if="!state.randomizerProgress.cancelRequested">Applying vibrant paints…</span>
+        <span ng-if="state.randomizerProgress.cancelRequested">Canceling randomization…</span>
+      </div>
+      <div class="dialog-actions">
+        <button type="button"
+                class="cancel"
+                ng-click="cancelRandomizeAllPartColors()"
+                ng-disabled="state.randomizerProgress.cancelRequested">
+          Cancel randomizing colors
+        </button>
+      </div>
+    </div>
+  </div>
   <div class="config-confirm-overlay" ng-if="state.liveryEditorConfirmation.visible">
     <div class="config-confirm-dialog">
       <h4>Vehicle Livery Editor</h4>
@@ -2081,7 +2201,7 @@
               <button type="button"
                       class="primary"
                       ng-click="randomizeAllPartColors()"
-                      ng-disabled="!(state.parts && state.parts.length)">
+                      ng-disabled="!(state.parts && state.parts.length) || state.randomizerProgress.active">
                 Randomize custom colors
               </button>
             </div>

--- a/ui/modules/apps/vehiclePartsPainting/app.html
+++ b/ui/modules/apps/vehiclePartsPainting/app.html
@@ -1012,6 +1012,56 @@
     .vehicle-parts-painting .base-paint-panel.is-collapsed .base-paint-body {
       display: none;
     }
+    .vehicle-parts-painting .randomizer-panel {
+      padding: 0;
+      gap: 0;
+    }
+    .vehicle-parts-painting .randomizer-panel.is-collapsed {
+      flex: 0 0 auto;
+    }
+    .vehicle-parts-painting .randomizer-panel .randomizer-header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 12px 12px 6px 12px;
+      cursor: pointer;
+    }
+    .vehicle-parts-painting .randomizer-panel.is-collapsed,
+    .vehicle-parts-painting .randomizer-panel.is-collapsed .randomizer-header {
+      cursor: pointer;
+    }
+    .vehicle-parts-painting .randomizer-panel .header-actions {
+      display: flex;
+      align-items: flex-start;
+      gap: 8px;
+    }
+    .vehicle-parts-painting .randomizer-panel .collapse-toggle {
+      background: transparent;
+      border: 1px solid rgba(255, 255, 255, 0.3);
+      color: inherit;
+      padding: 4px 10px;
+      border-radius: 4px;
+      font-size: 12px;
+    }
+    .vehicle-parts-painting .randomizer-panel .collapse-toggle:hover {
+      border-color: rgba(255, 255, 255, 0.6);
+    }
+    .vehicle-parts-painting .randomizer-panel .randomizer-body {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      padding: 0 12px 12px 12px;
+    }
+    .vehicle-parts-painting .randomizer-panel.is-collapsed .randomizer-body {
+      display: none;
+    }
+    .vehicle-parts-painting .randomizer-panel .randomizer-body p {
+      margin: 0;
+      font-size: 13px;
+      line-height: 1.45;
+      opacity: 0.85;
+    }
     .vehicle-parts-painting .part-paint-panel .part-paint-body {
       display: flex;
       flex-direction: column;
@@ -2001,6 +2051,39 @@
             <div class="editor-actions">
               <button type="button" class="primary" ng-click="applyBasePaints()">Apply base color</button>
               <button type="button" class="secondary" ng-click="resetBasePaintEditors()">Reset base color</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="editor-panel randomizer-panel"
+             ng-if="state.vehicleId"
+             ng-class="{'is-collapsed': state.randomizerCollapsed}"
+             ng-click="onRandomizerPanelClick($event)">
+          <div class="randomizer-header"
+               ng-click="onRandomizerHeaderClick($event)">
+            <div class="part-summary">
+              <h3>Randomize custom colors</h3>
+              <div class="meta">Give every part a unique random paint color.</div>
+            </div>
+            <div class="header-actions">
+              <button type="button"
+                      class="collapse-toggle"
+                      ng-click="toggleRandomizerCollapsed()"
+                      ng-attr-aria-expanded="{{!state.randomizerCollapsed}}"
+                      aria-controls="vehicleRandomizerBody">
+                {{state.randomizerCollapsed ? 'Expand' : 'Collapse'}}
+              </button>
+            </div>
+          </div>
+          <div class="randomizer-body" id="vehicleRandomizerBody">
+            <p>Apply a random custom color to every paintable vehicle part. This replaces any existing custom colors.</p>
+            <div class="editor-actions">
+              <button type="button"
+                      class="primary"
+                      ng-click="randomizeAllPartColors()"
+                      ng-disabled="!(state.parts && state.parts.length)">
+                Randomize custom colors
+              </button>
             </div>
           </div>
         </div>

--- a/ui/modules/apps/vehiclePartsPainting/app.js
+++ b/ui/modules/apps/vehiclePartsPainting/app.js
@@ -58,6 +58,16 @@ angular.module('beamng.apps')
         minimizedInlineStyle: {},
         basePaintCollapsed: false,
         randomizerCollapsed: true,
+        randomizerProgress: {
+          active: false,
+          visible: false,
+          cancelRequested: false,
+          total: 0,
+          processedCount: 0,
+          currentIndex: 0,
+          currentPartLabel: '',
+          currentPartPath: null
+        },
         partPaintCollapsed: false,
         configToolsCollapsed: false,
         savedConfigs: [],
@@ -113,6 +123,8 @@ angular.module('beamng.apps')
       };
       let suppressHsvSync = false;
       let hsvRectDragging = false;
+      const RANDOMIZER_STEP_DELAY_MS = 40;
+      let randomizerRun = null;
 
       $scope.colorPickerState = colorPickerState;
 
@@ -857,6 +869,12 @@ angular.module('beamng.apps')
 
       function resetUiForWorldChange() {
         $scope.$evalAsync(function () {
+          if (randomizerRun) {
+            state.randomizerProgress.cancelRequested = true;
+            finalizeRandomizer({ skipRefresh: true });
+          } else {
+            resetRandomizerProgress();
+          }
           state.vehicleId = null;
           state.parts = [];
           state.partsTree = [];
@@ -1681,6 +1699,159 @@ end)()`;
         return paints;
       }
 
+      function resetRandomizerProgress() {
+        const progress = state.randomizerProgress;
+        progress.active = false;
+        progress.visible = false;
+        progress.cancelRequested = false;
+        progress.total = 0;
+        progress.processedCount = 0;
+        progress.currentIndex = 0;
+        progress.currentPartLabel = '';
+        progress.currentPartPath = null;
+      }
+
+      function completeRandomizerFinalize(run) {
+        if (!run) { return; }
+        if (run.pendingPromise) {
+          $timeout.cancel(run.pendingPromise);
+          run.pendingPromise = null;
+        }
+
+        if (run.updatedAny && !run.skipRefresh) {
+          refreshCustomBadgeVisibility();
+          computeFilteredParts();
+        }
+
+        resetRandomizerProgress();
+        randomizerRun = null;
+      }
+
+      function finalizeRandomizer(options) {
+        if (!randomizerRun) {
+          resetRandomizerProgress();
+          return;
+        }
+
+        const run = randomizerRun;
+        if (options && options.skipRefresh) {
+          run.skipRefresh = true;
+        }
+
+        if (run.finishing) {
+          if (!run.processing) {
+            completeRandomizerFinalize(run);
+          }
+          return;
+        }
+
+        run.finishing = true;
+
+        if (run.processing) {
+          return;
+        }
+
+        completeRandomizerFinalize(run);
+      }
+
+      function processRandomizerStep() {
+        const run = randomizerRun;
+        if (!run) { return; }
+
+        if (run.finishing) {
+          finalizeRandomizer();
+          return;
+        }
+
+        run.pendingPromise = null;
+        run.processing = true;
+
+        const progress = state.randomizerProgress;
+
+        if (progress.cancelRequested) {
+          run.processing = false;
+          finalizeRandomizer();
+          return;
+        }
+
+        if (run.current >= run.tasks.length) {
+          run.processing = false;
+          finalizeRandomizer();
+          return;
+        }
+
+        const task = run.tasks[run.current];
+        progress.currentIndex = run.current;
+        progress.currentPartLabel = task.displayName || 'Part';
+        progress.currentPartPath = task.partPath || null;
+
+        const part = findPartByPath(task.partPath);
+        const paints = createRandomizedPaintsForPart(part);
+
+        if (run.finishing) {
+          run.processing = false;
+          finalizeRandomizer();
+          return;
+        }
+
+        if (Array.isArray(paints) && paints.length) {
+          const updatedLocally = updateLocalPartPaintState(task.partPath, paints, true);
+          if (updatedLocally) {
+            run.updatedAny = true;
+            const payload = {
+              partPath: task.partPath,
+              partName: task.partName || null,
+              slotPath: task.slotPath || null,
+              paints: paints
+            };
+            sendExtensionCommand('freeroam_vehiclePartsPainting.applyPartPaintJson(' + toLuaString(JSON.stringify(payload)) + ')');
+          }
+        }
+
+        run.current++;
+        progress.processedCount = run.current;
+
+        run.processing = false;
+
+        if (run.finishing || progress.cancelRequested) {
+          finalizeRandomizer();
+          return;
+        }
+
+        if (run.current >= run.tasks.length) {
+          finalizeRandomizer();
+          return;
+        }
+
+        run.pendingPromise = $timeout(processRandomizerStep, RANDOMIZER_STEP_DELAY_MS);
+      }
+
+      function beginRandomizerRun(tasks) {
+        if (!Array.isArray(tasks) || !tasks.length) { return; }
+        const progress = state.randomizerProgress;
+
+        progress.active = true;
+        progress.visible = true;
+        progress.cancelRequested = false;
+        progress.total = tasks.length;
+        progress.processedCount = 0;
+        progress.currentIndex = 0;
+        progress.currentPartLabel = '';
+        progress.currentPartPath = null;
+
+        randomizerRun = {
+          tasks: tasks,
+          current: 0,
+          pendingPromise: null,
+          updatedAny: false,
+          processing: false,
+          finishing: false,
+          skipRefresh: false
+        };
+
+        processRandomizerStep();
+      }
+
       function syncBasePaintEditorsFromState() {
         if (!Array.isArray(state.basePaints) || !state.basePaints.length) {
           $scope.basePaintEditors = [];
@@ -1989,36 +2160,41 @@ end)()`;
 
       $scope.randomizeAllPartColors = function () {
         if (!state.vehicleId) { return; }
+        if (state.randomizerProgress.active) { return; }
         if (!Array.isArray(state.parts) || !state.parts.length) { return; }
-        const parts = state.parts.slice();
-        const commands = [];
-        let updatedAny = false;
 
-        for (let i = 0; i < parts.length; i++) {
-          const part = parts[i];
+        const tasks = [];
+        for (let i = 0; i < state.parts.length; i++) {
+          const part = state.parts[i];
           if (!part || !part.partPath) { continue; }
-          const paints = createRandomizedPaintsForPart(part);
-          if (!Array.isArray(paints) || !paints.length) { continue; }
-          const updatedLocally = updateLocalPartPaintState(part.partPath, paints, true);
-          if (!updatedLocally) { continue; }
-          updatedAny = true;
-          const payload = {
+          tasks.push({
             partPath: part.partPath,
             partName: part.partName || null,
             slotPath: part.slotPath || null,
-            paints: paints
-          };
-          commands.push('freeroam_vehiclePartsPainting.applyPartPaintJson(' + toLuaString(JSON.stringify(payload)) + ')');
+            displayName: part.displayName || part.partName || part.partPath || 'Part'
+          });
         }
 
-        if (!updatedAny) { return; }
+        if (!tasks.length) { return; }
 
-        refreshCustomBadgeVisibility();
-        computeFilteredParts();
+        beginRandomizerRun(tasks);
+      };
 
-        for (let i = 0; i < commands.length; i++) {
-          sendExtensionCommand(commands[i]);
-        }
+      $scope.cancelRandomizeAllPartColors = function () {
+        if (!state.randomizerProgress.active || !randomizerRun) { return; }
+        if (state.randomizerProgress.cancelRequested) { return; }
+
+        state.randomizerProgress.cancelRequested = true;
+
+        finalizeRandomizer();
+      };
+
+      $scope.getRandomizerProgressWidth = function () {
+        const progress = state.randomizerProgress;
+        if (!progress || !progress.total) { return '0%'; }
+        const ratio = Math.max(0, Math.min(1, progress.processedCount / progress.total));
+        const percent = Math.round(ratio * 100);
+        return percent + '%';
       };
 
       $scope.hasBasePaintChanges = function () {

--- a/ui/modules/apps/vehiclePartsPainting/app.js
+++ b/ui/modules/apps/vehiclePartsPainting/app.js
@@ -57,6 +57,7 @@ angular.module('beamng.apps')
         minimizedAlignment: 'left',
         minimizedInlineStyle: {},
         basePaintCollapsed: false,
+        randomizerCollapsed: true,
         partPaintCollapsed: false,
         configToolsCollapsed: false,
         savedConfigs: [],
@@ -1574,6 +1575,72 @@ end)()`;
         return result;
       }
 
+      function createDefaultPaintTemplate() {
+        return {
+          baseColor: [1, 1, 1, 1],
+          metallic: 0,
+          roughness: 0,
+          clearcoat: 0,
+          clearcoatRoughness: 0
+        };
+      }
+
+      function createRandomizedPaintsForPart(part) {
+        const templateCandidates = [];
+        if (part) {
+          templateCandidates.push(part.customPaints, part.currentPaints, part.paints);
+        }
+        templateCandidates.push(state.basePaints);
+
+        let template = [];
+        for (let i = 0; i < templateCandidates.length; i++) {
+          const candidate = templateCandidates[i];
+          if (Array.isArray(candidate) && candidate.length) {
+            template = candidate;
+            break;
+          }
+        }
+
+        const baseFallback = Array.isArray(state.basePaints) && state.basePaints.length ? state.basePaints : null;
+        let count = template.length;
+        if (!count && baseFallback) {
+          count = baseFallback.length;
+        }
+        if (!count) {
+          count = 3;
+        }
+        count = Math.max(1, Math.min(3, count));
+
+        const paints = [];
+        for (let i = 0; i < count; i++) {
+          let source = template[i] || null;
+          if (!source && template.length) {
+            source = template[template.length - 1];
+          }
+          if (!source && baseFallback) {
+            source = baseFallback[Math.min(i, baseFallback.length - 1)];
+          }
+
+          let clone = clonePaint(source);
+          if (!clone) {
+            clone = createDefaultPaintTemplate();
+          }
+
+          const baseColor = Array.isArray(clone.baseColor) ? clone.baseColor : [];
+          const alpha = typeof baseColor[3] === 'number' ? clamp01(baseColor[3]) : 1;
+          clone.baseColor = [
+            clamp01(Math.random()),
+            clamp01(Math.random()),
+            clamp01(Math.random()),
+            alpha
+          ];
+
+          paints.push(clone);
+        }
+
+        return paints;
+      }
+
       function syncBasePaintEditorsFromState() {
         if (!Array.isArray(state.basePaints) || !state.basePaints.length) {
           $scope.basePaintEditors = [];
@@ -1879,6 +1946,40 @@ end)()`;
           computeFilteredParts();
         }
       }
+
+      $scope.randomizeAllPartColors = function () {
+        if (!state.vehicleId) { return; }
+        if (!Array.isArray(state.parts) || !state.parts.length) { return; }
+        const parts = state.parts.slice();
+        const commands = [];
+        let updatedAny = false;
+
+        for (let i = 0; i < parts.length; i++) {
+          const part = parts[i];
+          if (!part || !part.partPath) { continue; }
+          const paints = createRandomizedPaintsForPart(part);
+          if (!Array.isArray(paints) || !paints.length) { continue; }
+          const updatedLocally = updateLocalPartPaintState(part.partPath, paints, true);
+          if (!updatedLocally) { continue; }
+          updatedAny = true;
+          const payload = {
+            partPath: part.partPath,
+            partName: part.partName || null,
+            slotPath: part.slotPath || null,
+            paints: paints
+          };
+          commands.push('freeroam_vehiclePartsPainting.applyPartPaintJson(' + toLuaString(JSON.stringify(payload)) + ')');
+        }
+
+        if (!updatedAny) { return; }
+
+        refreshCustomBadgeVisibility();
+        computeFilteredParts();
+
+        for (let i = 0; i < commands.length; i++) {
+          sendExtensionCommand(commands[i]);
+        }
+      };
 
       $scope.hasBasePaintChanges = function () {
         if (!$scope.basePaintEditors || !$scope.basePaintEditors.length) { return false; }
@@ -2931,6 +3032,10 @@ end)()`;
         state.partPaintCollapsed = !state.partPaintCollapsed;
       };
 
+      $scope.toggleRandomizerCollapsed = function () {
+        state.randomizerCollapsed = !state.randomizerCollapsed;
+      };
+
       $scope.toggleConfigToolsCollapsed = function () {
         state.configToolsCollapsed = !state.configToolsCollapsed;
       };
@@ -2967,6 +3072,23 @@ end)()`;
           $event.stopPropagation();
         }
         state.basePaintCollapsed = !state.basePaintCollapsed;
+      };
+
+      $scope.onRandomizerPanelClick = function ($event) {
+        if (isCollapseToggleEvent($event)) { return; }
+        if (!state.randomizerCollapsed) { return; }
+        if ($event && typeof $event.stopPropagation === 'function') {
+          $event.stopPropagation();
+        }
+        state.randomizerCollapsed = false;
+      };
+
+      $scope.onRandomizerHeaderClick = function ($event) {
+        if (isCollapseToggleEvent($event)) { return; }
+        if ($event && typeof $event.stopPropagation === 'function') {
+          $event.stopPropagation();
+        }
+        state.randomizerCollapsed = !state.randomizerCollapsed;
       };
 
       $scope.onPartPaintPanelClick = function ($event) {
@@ -3371,6 +3493,7 @@ end)()`;
             state.motionWarning.pending = false;
             state.motionWarning.speed = 0;
             state.motionWarning.vehicleId = null;
+            state.randomizerCollapsed = true;
             return;
           }
 

--- a/ui/modules/apps/vehiclePartsPainting/app.js
+++ b/ui/modules/apps/vehiclePartsPainting/app.js
@@ -871,7 +871,7 @@ angular.module('beamng.apps')
         $scope.$evalAsync(function () {
           if (randomizerRun) {
             state.randomizerProgress.cancelRequested = true;
-            finalizeRandomizer({ skipRefresh: true });
+            finalizeRandomizer({ skipRefresh: true, force: true });
           } else {
             resetRandomizerProgress();
           }
@@ -1718,6 +1718,9 @@ end)()`;
           run.pendingPromise = null;
         }
 
+        run.awaitingResult = false;
+        run.activeTask = null;
+
         if (run.updatedAny && !run.skipRefresh) {
           refreshCustomBadgeVisibility();
           computeFilteredParts();
@@ -1738,8 +1741,14 @@ end)()`;
           run.skipRefresh = true;
         }
 
+        if (options && options.force) {
+          run.finishing = true;
+          completeRandomizerFinalize(run);
+          return;
+        }
+
         if (run.finishing) {
-          if (!run.processing) {
+          if (!run.awaitingResult) {
             completeRandomizerFinalize(run);
           }
           return;
@@ -1747,11 +1756,97 @@ end)()`;
 
         run.finishing = true;
 
-        if (run.processing) {
+        if (run.awaitingResult) {
           return;
         }
 
         completeRandomizerFinalize(run);
+      }
+
+      function normalizeRandomizerString(value) {
+        if (typeof value !== 'string') { return null; }
+        const trimmed = value.trim();
+        if (!trimmed) { return null; }
+        return trimmed.toLowerCase();
+      }
+
+      function randomizerResultMatchesTask(result, task) {
+        if (!task) { return false; }
+        const taskPath = normalizeRandomizerString(task.partPath);
+        const taskName = normalizeRandomizerString(task.partName);
+        const taskSlot = normalizeRandomizerString(task.slotPath);
+
+        const resultPath = normalizeRandomizerString(result.partPath || result.path);
+        const resultName = normalizeRandomizerString(result.partName || result.name);
+        const resultSlot = normalizeRandomizerString(result.slotPath || result.slot || result.slotName);
+
+        if (taskPath && resultPath && taskPath === resultPath) { return true; }
+        if (taskName && resultName && taskName === resultName) { return true; }
+        if (taskSlot && resultSlot && taskSlot === resultSlot) { return true; }
+
+        return false;
+      }
+
+      function scheduleNextRandomizerStep() {
+        if (!randomizerRun) { return; }
+        if (randomizerRun.pendingPromise) {
+          $timeout.cancel(randomizerRun.pendingPromise);
+          randomizerRun.pendingPromise = null;
+        }
+        randomizerRun.pendingPromise = $timeout(function () {
+          if (!randomizerRun) { return; }
+          randomizerRun.pendingPromise = null;
+          processRandomizerStep();
+        }, RANDOMIZER_STEP_DELAY_MS);
+      }
+
+      function handleRandomizerApplyResult(data) {
+        if (!randomizerRun || !state.randomizerProgress.active) { return; }
+
+        const run = randomizerRun;
+        if (!run.awaitingResult || !run.activeTask) { return; }
+
+        let vehicleId = data && data.vehicleId;
+        if (vehicleId !== undefined && vehicleId !== null && vehicleId !== false) {
+          const numericVehicleId = Number(vehicleId);
+          if (!Number.isNaN(numericVehicleId)) {
+            vehicleId = numericVehicleId;
+          }
+        }
+        if (state.vehicleId !== null && state.vehicleId !== undefined && state.vehicleId !== false) {
+          if (vehicleId !== undefined && vehicleId !== null && vehicleId !== false && vehicleId !== state.vehicleId) {
+            return;
+          }
+        }
+
+        if (!data || typeof data !== 'object') {
+          return;
+        }
+
+        const normalized = data;
+        if (!randomizerResultMatchesTask(normalized, run.activeTask)) {
+          return;
+        }
+
+        run.awaitingResult = false;
+        run.activeTask = null;
+
+        const successValue = normalized.success;
+        const wasSuccessful = successValue === true || successValue === 'true' || successValue === 1;
+        if (!wasSuccessful && normalized.errorMessage && globalWindow && globalWindow.console && typeof globalWindow.console.warn === 'function') {
+          globalWindow.console.warn('VehiclePartsPainting: Part paint application failed during randomize operation.', normalized);
+        }
+
+        run.current++;
+        const progress = state.randomizerProgress;
+        progress.processedCount = Math.min(run.current, progress.total || run.current);
+
+        if (run.finishing || progress.cancelRequested || run.current >= run.tasks.length) {
+          finalizeRandomizer();
+          return;
+        }
+
+        scheduleNextRandomizerStep();
       }
 
       function processRandomizerStep() {
@@ -1763,24 +1858,23 @@ end)()`;
           return;
         }
 
-        run.pendingPromise = null;
-        run.processing = true;
+        if (run.awaitingResult) {
+          return;
+        }
 
         const progress = state.randomizerProgress;
-
         if (progress.cancelRequested) {
-          run.processing = false;
           finalizeRandomizer();
           return;
         }
 
         if (run.current >= run.tasks.length) {
-          run.processing = false;
           finalizeRandomizer();
           return;
         }
 
         const task = run.tasks[run.current];
+        run.activeTask = task;
         progress.currentIndex = run.current;
         progress.currentPartLabel = task.displayName || 'Part';
         progress.currentPartPath = task.partPath || null;
@@ -1788,12 +1882,7 @@ end)()`;
         const part = findPartByPath(task.partPath);
         const paints = createRandomizedPaintsForPart(part);
 
-        if (run.finishing) {
-          run.processing = false;
-          finalizeRandomizer();
-          return;
-        }
-
+        let commandQueued = false;
         if (Array.isArray(paints) && paints.length) {
           const updatedLocally = updateLocalPartPaintState(task.partPath, paints, true);
           if (updatedLocally) {
@@ -1805,25 +1894,25 @@ end)()`;
               paints: paints
             };
             sendExtensionCommand('freeroam_vehiclePartsPainting.applyPartPaintJson(' + toLuaString(JSON.stringify(payload)) + ')');
+            commandQueued = true;
           }
         }
 
+        if (commandQueued) {
+          run.awaitingResult = true;
+          return;
+        }
+
+        run.activeTask = null;
         run.current++;
-        progress.processedCount = run.current;
+        progress.processedCount = Math.min(run.current, progress.total || run.current);
 
-        run.processing = false;
-
-        if (run.finishing || progress.cancelRequested) {
+        if (run.finishing || progress.cancelRequested || run.current >= run.tasks.length) {
           finalizeRandomizer();
           return;
         }
 
-        if (run.current >= run.tasks.length) {
-          finalizeRandomizer();
-          return;
-        }
-
-        run.pendingPromise = $timeout(processRandomizerStep, RANDOMIZER_STEP_DELAY_MS);
+        scheduleNextRandomizerStep();
       }
 
       function beginRandomizerRun(tasks) {
@@ -1844,9 +1933,10 @@ end)()`;
           current: 0,
           pendingPromise: null,
           updatedAny: false,
-          processing: false,
           finishing: false,
-          skipRefresh: false
+          skipRefresh: false,
+          awaitingResult: false,
+          activeTask: null
         };
 
         processRandomizerStep();
@@ -3769,6 +3859,13 @@ end)()`;
           computeFilteredParts();
           state.isSpawningConfig = false;
           state.isSavingConfig = false;
+        });
+      });
+
+      $scope.$on('VehiclePartsPaintingApplyResult', function (event, data) {
+        markExtensionAvailable();
+        $scope.$evalAsync(function () {
+          handleRandomizerApplyResult(data || {});
         });
       });
 

--- a/ui/modules/apps/vehiclePartsPainting/app.js
+++ b/ui/modules/apps/vehiclePartsPainting/app.js
@@ -1585,6 +1585,45 @@ end)()`;
         };
       }
 
+      const GOLDEN_RATIO_CONJUGATE = 0.6180339887498948;
+      let randomizerHueSeed = Math.random();
+
+      function hueToChannel(p, q, t) {
+        if (t < 0) { t += 1; }
+        if (t > 1) { t -= 1; }
+        if (t < (1 / 6)) { return p + (q - p) * 6 * t; }
+        if (t < (1 / 2)) { return q; }
+        if (t < (2 / 3)) { return p + (q - p) * ((2 / 3) - t) * 6; }
+        return p;
+      }
+
+      function hslToRgbNormalized(hueDegrees, saturation, lightness) {
+        const normalizedHue = ((hueDegrees % 360) + 360) % 360 / 360;
+        const s = clamp01(saturation);
+        const l = clamp01(lightness);
+
+        if (s === 0) {
+          return [l, l, l];
+        }
+
+        const q = l < 0.5 ? l * (1 + s) : l + s - (l * s);
+        const p = (2 * l) - q;
+
+        const r = hueToChannel(p, q, normalizedHue + (1 / 3));
+        const g = hueToChannel(p, q, normalizedHue);
+        const b = hueToChannel(p, q, normalizedHue - (1 / 3));
+
+        return [clamp01(r), clamp01(g), clamp01(b)];
+      }
+
+      function generateVibrantPastelColor() {
+        randomizerHueSeed = (randomizerHueSeed + GOLDEN_RATIO_CONJUGATE) % 1;
+        const hue = randomizerHueSeed * 360;
+        const saturation = 0.65 + (Math.random() * 0.3);
+        const lightness = 0.55 + (Math.random() * 0.2);
+        return hslToRgbNormalized(hue, saturation, lightness);
+      }
+
       function createRandomizedPaintsForPart(part) {
         const templateCandidates = [];
         if (part) {
@@ -1628,10 +1667,11 @@ end)()`;
 
           const baseColor = Array.isArray(clone.baseColor) ? clone.baseColor : [];
           const alpha = typeof baseColor[3] === 'number' ? clamp01(baseColor[3]) : 1;
+          const pastelColor = generateVibrantPastelColor();
           clone.baseColor = [
-            clamp01(Math.random()),
-            clamp01(Math.random()),
-            clamp01(Math.random()),
+            pastelColor[0],
+            pastelColor[1],
+            pastelColor[2],
             alpha
           ];
 


### PR DESCRIPTION
## Summary
- add a collapsible randomizer panel to the editor sidebar with explanatory copy and a "Randomize custom colors" action
- implement random paint generation for every part and queue commands to apply the colors while keeping local state in sync
- default the new panel to collapsed when no vehicle data is available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2e4d30ad88329b9f411163cf57fdc