### PR TITLE
Optimize saved config refresh to reduce UI stutter

### DIFF
--- a/.tests/vehiclePartsPainting.test.js
+++ b/.tests/vehiclePartsPainting.test.js
@@ -591,7 +591,7 @@ function resetPaint(scope, partPath) {
     return command.indexOf('freeroam_vehiclePartsPainting.requestState()') !== -1;
   }), 'Queued requestState command should execute after extension becomes available');
   assert(executedAfterReady.some(function (command) {
-    return command.indexOf('freeroam_vehiclePartsPainting.requestSavedConfigs()') !== -1;
+    return command.indexOf('freeroam_vehiclePartsPainting.requestSavedConfigs(') !== -1;
   }), 'Queued requestSavedConfigs command should execute after extension becomes available');
   assert.strictEqual(guardedCommandCallbacks >= 2, true,
     'Guarded command callbacks should be invoked for each queued command');
@@ -684,7 +684,7 @@ function resetPaint(scope, partPath) {
     return command.indexOf('freeroam_vehiclePartsPainting.requestState()') !== -1;
   }), 'World ready initialization should queue a requestState command');
   assert(queueSnapshot.some(function (command) {
-    return command.indexOf('freeroam_vehiclePartsPainting.requestSavedConfigs()') !== -1;
+    return command.indexOf('freeroam_vehiclePartsPainting.requestSavedConfigs(') !== -1;
   }), 'World ready initialization should queue a requestSavedConfigs command');
 
   const loadCallsAfter = bngApiCalls.filter(function (command) {

--- a/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
+++ b/lua/ge/extensions/freeroam/vehiclePartsPainting.lua
@@ -19,6 +19,16 @@ local partDescriptorsByVeh = {}
 local activePartIdSetByVeh = {}
 local ensuredPartConditionsByVeh = {}
 local savedConfigCacheByVeh = {}
+
+local function invalidateSavedConfigCache(vehId)
+  if vehId ~= nil then
+    if vehId ~= -1 then
+      savedConfigCacheByVeh[vehId] = nil
+    end
+    return
+  end
+  savedConfigCacheByVeh = {}
+end
 local userColorPresets = nil
 local lastKnownPlayerVehicleId = nil
 local activeScreenshotPauseState = nil
@@ -2009,28 +2019,40 @@ local function gatherSavedConfigsFromDisk(modelFolder)
   return list
 end
 
-local function getSavedConfigs(vehId, vehData, vehObj)
+local function getSavedConfigs(vehId, vehData, vehObj, forceRefresh)
   local modelId = normalizeModelFolder(getVehicleModelIdentifier(vehData, vehObj, vehId))
   if not modelId then
     return {}
   end
 
+  local useCache = not forceRefresh and vehId and vehId ~= -1
+  if useCache then
+    local cache = savedConfigCacheByVeh[vehId]
+    if cache and cache.model == modelId and type(cache.list) == 'table' then
+      return deepCopy(cache.list)
+    end
+  end
+
   local configs = gatherSavedConfigsFromDisk(modelId)
-  savedConfigCacheByVeh[vehId] = {
-    model = modelId,
-    list = configs
-  }
+
+  if vehId and vehId ~= -1 then
+    savedConfigCacheByVeh[vehId] = {
+      model = modelId,
+      list = deepCopy(configs)
+    }
+  end
+
   return configs
 end
 
-local function sendSavedConfigs(vehId, vehData, vehObj)
+local function sendSavedConfigs(vehId, vehData, vehObj, forceRefresh)
   if not vehId or vehId == -1 then
     guihooks.trigger('VehiclePartsPaintingSavedConfigs', { vehicleId = -1, configs = {} })
     return
   end
   vehData = vehData or vehManager.getVehicleData(vehId)
   vehObj = vehObj or getObjectByID(vehId)
-  local configs = getSavedConfigs(vehId, vehData, vehObj)
+  local configs = getSavedConfigs(vehId, vehData, vehObj, forceRefresh)
   local payload = {
     vehicleId = vehId,
     configs = configs
@@ -2114,7 +2136,8 @@ local function saveCurrentUserConfig(configName)
     end
   end
 
-  sendSavedConfigs(vehId, vehData, vehObj)
+  invalidateSavedConfigCache(vehId)
+  sendSavedConfigs(vehId, vehData, vehObj, true)
 end
 
 local function deleteSavedConfiguration(configPath)
@@ -2189,13 +2212,15 @@ local function deleteSavedConfiguration(configPath)
 
   local vehId = be:getPlayerVehicleID(0)
   if not vehId or vehId == -1 then
+    invalidateSavedConfigCache()
     sendSavedConfigs(-1)
     return
   end
 
   local vehObj = getObjectByID(vehId)
   local vehData = vehManager.getVehicleData(vehId)
-  sendSavedConfigs(vehId, vehData, vehObj)
+  invalidateSavedConfigCache()
+  sendSavedConfigs(vehId, vehData, vehObj, true)
 end
 
 local function spawnUserConfig(configPath)
@@ -3847,7 +3872,7 @@ local function requestState()
   sendState()
 end
 
-local function requestSavedConfigs()
+local function requestSavedConfigs(forceRefresh)
   local vehId = be:getPlayerVehicleID(0)
   if not vehId or vehId == -1 then
     sendSavedConfigs(-1)
@@ -3855,7 +3880,7 @@ local function requestSavedConfigs()
   end
   local vehObj = getObjectByID(vehId)
   local vehData = vehManager.getVehicleData(vehId)
-  sendSavedConfigs(vehId, vehData, vehObj)
+  sendSavedConfigs(vehId, vehData, vehObj, forceRefresh == true)
 end
 
 local function saveCurrentConfiguration(name)

--- a/ui/modules/apps/vehiclePartsPainting/app.js
+++ b/ui/modules/apps/vehiclePartsPainting/app.js
@@ -1477,7 +1477,7 @@ end)()`;
         if (replaceTarget) {
           markSavedConfigPreviewForRefresh(replaceTarget);
         }
-        scheduleSavedConfigRefresh(SAVED_CONFIG_FAST_REFRESH_INTERVAL_MS);
+        scheduleSavedConfigRefresh(SAVED_CONFIG_FAST_REFRESH_INTERVAL_MS, true);
         const command = 'freeroam_vehiclePartsPainting.saveCurrentConfiguration(' + toLuaString(name) + ')';
         sendExtensionCommand(command);
       }
@@ -2341,8 +2341,15 @@ end)()`;
         sendExtensionCommand('freeroam_vehiclePartsPainting.showAllParts()');
       }
 
-      function requestSavedConfigs() {
-        sendExtensionCommand('freeroam_vehiclePartsPainting.requestSavedConfigs()');
+      function requestSavedConfigs(options) {
+        let force = false;
+        if (options && typeof options === 'object') {
+          force = options.force === true;
+        } else {
+          force = options === true;
+        }
+        const command = 'freeroam_vehiclePartsPainting.requestSavedConfigs(' + (force ? 'true' : 'false') + ')';
+        sendExtensionCommand(command);
       }
 
       registerWorldReadyListener('VehiclePartsPaintingWorldReady');
@@ -2367,13 +2374,14 @@ end)()`;
         }
       }
 
-      function scheduleSavedConfigRefresh(delay) {
+      function scheduleSavedConfigRefresh(delay, options) {
         cancelSavedConfigRefreshTimer();
         if (typeof delay !== 'number' || !isFinite(delay) || delay < 0) { return; }
+        const force = !!(options && (options === true || options.force === true));
         savedConfigRefreshTimeout = $timeout(function () {
           savedConfigRefreshTimeout = null;
           if (!state.vehicleId) { return; }
-          requestSavedConfigs();
+          requestSavedConfigs(force);
         }, delay);
       }
 
@@ -3419,7 +3427,7 @@ end)()`;
       };
 
       $scope.refreshSavedConfigs = function () {
-        requestSavedConfigs();
+        requestSavedConfigs(true);
       };
 
       function getSavedConfigDisplayName(config) {
@@ -3622,7 +3630,7 @@ end)()`;
         }
         state.deleteConfigDialog.isDeleting = true;
         resetSavedConfigPreviewTracking();
-        scheduleSavedConfigRefresh(SAVED_CONFIG_FAST_REFRESH_INTERVAL_MS);
+        scheduleSavedConfigRefresh(SAVED_CONFIG_FAST_REFRESH_INTERVAL_MS, true);
         const command = 'freeroam_vehiclePartsPainting.deleteSavedConfiguration(' + toLuaString(target.relativePath) + ')';
         sendExtensionCommand(command);
       };
@@ -4000,7 +4008,7 @@ end)()`;
           if (state.vehicleId) {
             const hasPendingPreview = updateSavedConfigPreviewTracking(configs);
             if (hasPendingPreview) {
-              scheduleSavedConfigRefresh(SAVED_CONFIG_FAST_REFRESH_INTERVAL_MS);
+              scheduleSavedConfigRefresh(SAVED_CONFIG_FAST_REFRESH_INTERVAL_MS, true);
             } else {
               cancelSavedConfigRefreshTimer();
             }


### PR DESCRIPTION
## Summary
- cache saved configuration lookups in the freeroam extension and allow forced invalidation when files change
- update the UI app to request forced refreshes only when pending previews require them and default to cached results otherwise
- adjust unit tests for the new requestSavedConfigs command signature

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2f4145b6c8329a24ebead0d7141e7